### PR TITLE
Payload support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.5
   - 5.6
   - hhvm
+  - 7.0
 
 before_script:
   - composer install --prefer-source -n --no-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ php:
 
 before_script:
   - composer install --prefer-source -n --no-dev
+  - composer require spomky-labs/jose:2.0.x-dev
 
 script: phpunit -c phpunit.travis.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ matrix:
 
 before_script:
   - composer install --prefer-source -n --no-dev
-  - '[[ ${PAYLOAD} == "true" ]] && composer require spomky-labs/jose:2.0.x-dev'
+  - 'if [[ ${PAYLOAD} == "true" ]]; then composer require spomky-labs/jose:2.0.x-dev; fi'
 
 script: phpunit -c phpunit.travis.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,7 @@ php:
   - 5.6
   - hhvm
 
-env:
-  - PAYLOAD=true
-  - PAYLOAD=false
-
-matrix:
-  exclude:
-    - php: 5.4
-      env: PAYLOAD=true
-
 before_script:
   - composer install --prefer-source -n --no-dev
-  - 'if [[ ${PAYLOAD} == "true" ]]; then composer require spomky-labs/jose:2.0.x-dev; fi'
 
 script: phpunit -c phpunit.travis.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ matrix:
 
 before_script:
   - composer install --prefer-source -n --no-dev
-  - ${PAYLOAD} && composer require spomky-labs/jose:2.0.x-dev
+  - [[ ${PAYLOAD} == "true" ]] && composer require spomky-labs/jose:2.0.x-dev
 
 script: phpunit -c phpunit.travis.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,17 @@ php:
   - 5.6
   - hhvm
 
+env:
+  - PAYLOAD=true
+  - PAYLOAD=false
+
+matrix:
+  exclude:
+    - php: 5.4
+      env: PAYLOAD=true
+
 before_script:
   - composer install --prefer-source -n --no-dev
-  - composer require spomky-labs/jose:2.0.x-dev
+  - PAYLOAD && composer require spomky-labs/jose:2.0.x-dev
 
 script: phpunit -c phpunit.travis.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ matrix:
 
 before_script:
   - composer install --prefer-source -n --no-dev
-  - PAYLOAD && composer require spomky-labs/jose:2.0.x-dev
+  - ${PAYLOAD} && composer require spomky-labs/jose:2.0.x-dev
 
 script: phpunit -c phpunit.travis.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ php:
   - hhvm
 
 before_script:
-  - composer install --prefer-source -n
+  - composer install --prefer-source -n --no-dev
 
 script: phpunit -c phpunit.travis.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ matrix:
 
 before_script:
   - composer install --prefer-source -n --no-dev
-  - [[ ${PAYLOAD} == "true" ]] && composer require spomky-labs/jose:2.0.x-dev
+  - '[[ ${PAYLOAD} == "true" ]] && composer require spomky-labs/jose:2.0.x-dev'
 
 script: phpunit -c phpunit.travis.xml

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $endpoints = array(
 // array of payloads which are strings or null (json_encode your arrays)
 $payloads = array(
     'hello !',
-    '{'msg': 'test'}',
+    '{"msg":"test"}',
     null,
     '',
 );

--- a/README.md
+++ b/README.md
@@ -81,6 +81,25 @@ $webPush = new WebPush($apiKeys);
 $webPush->sendNotification($endpoint, null, null, true);
 ```
 
+### Payload length and security
+As previously stated, payload will be encrypted by the library. The maximum payload length is 4078 bytes (or ASCII characters).
+
+However, when you encrypt a string of a certain length, the resulting string will always have the same length,
+no matter how many times you encrypt the initial string. This can make attackers guess the content of the payload.
+In order to circumvent this, this library can add some null padding to the initial payload, so that all the input of the encryption process
+will have the same length. This way, all the output of the encryption process will also have the same length and attackers won't be able to 
+guess the content of your payload. The downside of this approach is that you will use more bandwidth than if you didn't pad the string.
+That's why the library provides the option to disable this security measure:
+
+```php
+<?php
+
+use Minishlink\WebPush\WebPush;
+
+$webPush = new WebPush();
+$webPush->setAutomaticPadding(false); // disable automatic padding
+```
+
 ### Time To Live
 Time To Live (TTL, in seconds) is how long a push message is retained by the push service (eg. Mozilla) in case the user browser 
 is not yet accessible (eg. is not connected). You may want to use a very long time for important notifications. The default TTL is 4 weeks. 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Time To Live (TTL, in seconds) is how long a push message is retained by the pus
 is not yet accessible (eg. is not connected). You may want to use a very long time for important notifications. The default TTL is 4 weeks. 
 However, if you send multiple nonessential notifications, set a TTL of 0: the push notification will be delivered only 
 if the user is currently connected. For other cases, you should use a minimum of one day if your users have multiple time 
-zones, and if you don't several hours will suffice.
+zones, and if they don't several hours will suffice.
 
 ```php
 <?php

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $notifications = array(
         'endpoint' => 'https://updates.push.services.mozilla.com/push/abc...', // Firefox 43+
         'payload' => 'hello !',
         'userPublicKey' => 'BPcMbnWQL5GOYX/5LKZXT6sLmHiMsJSiEvIFvfcDvX7IZ9qqtq68onpTPEYmyxSQNiH7UD/98AUcQ12kBoxz/0s=', // base 64 encoded, should be 88 chars
-        'userAuthToken' => 'RMpCEzkgBaVj0Zj0', // base 64 encoded, should be 16 chars
+        'userAuthToken' => 'CxVX6QsVToEGEcjfYPqXQw==', // base 64 encoded, should be 24 chars
     ), array(
         'endpoint' => 'https://android.googleapis.com/gcm/send/abcdef...', // Chrome
         'payload' => null,
@@ -36,9 +36,9 @@ $notifications = array(
         'userAuthToken' => null,
     ), array(
         'endpoint' => 'https://example.com/other/endpoint/of/another/vendor/abcdef...',
-        'payload' => '{"msg":"test"}',
+        'payload' => '{msg:"test"}',
         'userPublicKey' => '(stringOf88Chars)', 
-        'userAuthToken' => '(stringOf16Chars)',
+        'userAuthToken' => '(stringOf24Chars)',
     ),
 );
 
@@ -67,9 +67,6 @@ $webPush->sendNotification(
 
 ### GCM servers notes (Chrome)
 For compatibility reasons, this library detects if the server is a GCM server and appropriately sends the notification.
-GCM servers don't support encrypted payloads yet so WebPush will skip the payload.
-If you still want to show that payload on your notification, you should get that data on client-side from your server 
-where you will have to store somewhere the history of notifications.
 
 You will need to specify your GCM api key when instantiating WebPush:
 ```php
@@ -87,7 +84,7 @@ $webPush->sendNotification($endpoint, null, null, null, true);
 ```
 
 ### Payload length and security
-As previously stated, payload will be encrypted by the library. The maximum payload length is 4078 bytes (or ASCII characters).
+Payload will be encrypted by the library. The maximum payload length is 4078 bytes (or ASCII characters).
 
 However, when you encrypt a string of a certain length, the resulting string will always have the same length,
 no matter how many times you encrypt the initial string. This can make attackers guess the content of the payload.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ WebPush can be used to send notifications to endpoints which server delivers web
 the [Web Push API specification](http://www.w3.org/TR/push-api/).
 As it is standardized, you don't have to worry about what server type it relies on.
 
-__*Currently, WebPush doesn't support payloads at all.
-It is under development (see ["payload" branch](https://github.com/Minishlink/web-push/tree/payload)).*__
-
 ```php
 <?php
 
@@ -19,14 +16,34 @@ use Minishlink\WebPush\WebPush;
 
 // array of endpoints
 $endpoints = array(
-    'https://android.googleapis.com/gcm/send/abcdef...', // Chrome
-    'https://updates.push.services.mozilla.com/push/adcdef...', // Firefox 43+
-    'https://example.com/other/endpoint/of/another/vendor/abcdef...',
+    'https://updates.push.services.mozilla.com/push/abc...', // Firefox 43+
+    'https://updates.push.services.mozilla.com/push/def...',
+    'https://example.com/other/endpoint/of/another/vendor/abc...',
+    'https://example.com/other/endpoint/of/another/vendor/abc...',
+);
+
+// array of payloads which are strings or null (json_encode your arrays)
+$payloads = array(
+    'hello !',
+    '{'msg': 'test'}',
+    null,
+    '',
+);
+
+// array of the public keys of each users
+$userPublicKeys = array(
+    'thePublicKeysCorrespondingToFirstEndpoint',
+    'thePublicKeysCorrespondingToSecondEndpoint',
+    'thePublicKeysCorrespondingToThirdEndpoint',
+    'thePublicKeysCorrespondingToFourthEndpoint',
 );
 
 $webPush = new WebPush();
-$webPush->sendNotification($endpoints[0]); // send one notification
-$webPush->sendNotifications($endpoints); // send multiple notifications
+$webPush->sendNotification($endpoints[0]); // send one notification without payload
+$webPush->sendNotifications($endpoints); // send multiple notifications without payloads
+
+$webPush->sendNotification($endpoints[0], $payloads[0], $userPublicKeys[0]); // send one notification with payload
+$webPush->sendNotifications($endpoints, $payloads, $userPublicKeys); // send multiple notifications with payloads
 ```
 
 ### GCM servers notes (Chrome)
@@ -81,6 +98,9 @@ $browser = $webPush->getBrowser();
 
 ### Is the API stable?
 Not until the [Push API spec](http://www.w3.org/TR/push-api/) is finished.
+
+### What about security?
+Internally, WebPush uses the [phpecc](https://github.com/phpecc/phpecc) Elliptic Curve Cryptography library.
 
 ### How to solve "SSL certificate problem: unable to get local issuer certificate" ?
 Your installation lacks some certificates.

--- a/README.md
+++ b/README.md
@@ -27,15 +27,18 @@ $notifications = array(
     array(
         'endpoint' => 'https://updates.push.services.mozilla.com/push/abc...', // Firefox 43+
         'payload' => 'hello !',
-        'userPublicKey' => 'dahaj5365sq',
+        'userPublicKey' => 'BPcMbnWQL5GOYX/5LKZXT6sLmHiMsJSiEvIFvfcDvX7IZ9qqtq68onpTPEYmyxSQNiH7UD/98AUcQ12kBoxz/0s=', // base 64 encoded, should be 88 chars
+        'userAuthToken' => 'RMpCEzkgBaVj0Zj0', // base 64 encoded, should be 16 chars
     ), array(
         'endpoint' => 'https://android.googleapis.com/gcm/send/abcdef...', // Chrome
         'payload' => null,
         'userPublicKey' => null,
+        'userAuthToken' => null,
     ), array(
         'endpoint' => 'https://example.com/other/endpoint/of/another/vendor/abcdef...',
         'payload' => '{"msg":"test"}',
-        'userPublicKey' => 'fsqdjknadsanlk',
+        'userPublicKey' => '(stringOf88Chars)', 
+        'userAuthToken' => '(stringOf16Chars)',
     ),
 );
 
@@ -46,7 +49,8 @@ foreach ($notifications as $notification) {
     $webPush->sendNotification(
         $notification['endpoint'],
         $notification['payload'], // optional (defaults null)
-        $notification['userPublicKey'] // optional (defaults null)
+        $notification['userPublicKey'], // optional (defaults null)
+        $notification['userAuthToken'] // optional (defaults null)
     );
 }
 $webPush->flush();
@@ -56,6 +60,7 @@ $webPush->sendNotification(
     $notifications[0]['endpoint'],
     $notifications[0]['payload'], // optional (defaults null)
     $notifications[0]['userPublicKey'], // optional (defaults null)
+    $notifications[0]['userAuthToken'], // optional (defaults null)
     true // optional (defaults false)
 );
 ```
@@ -78,7 +83,7 @@ $apiKeys = array(
 );
 
 $webPush = new WebPush($apiKeys);
-$webPush->sendNotification($endpoint, null, null, true);
+$webPush->sendNotification($endpoint, null, null, null, true);
 ```
 
 ### Payload length and security

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ $browser = $webPush->getBrowser();
 Not until the [Push API spec](http://www.w3.org/TR/push-api/) is finished.
 
 ### What about security?
-Internally, WebPush uses the [phpecc](https://github.com/phpecc/phpecc) Elliptic Curve Cryptography library.
+Internally, WebPush uses the [phpecc](https://github.com/phpecc/phpecc) Elliptic Curve Cryptography library to create 
+local public and private keys and compute the shared secret. 
+Then, WebPush uses `openssl` in order to encrypt the payload with the encryption key.
 
 ### How to solve "SSL certificate problem: unable to get local issuer certificate" ?
 Your installation lacks some certificates.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 ## Installation
 `composer require minishlink/web-push`
 
+If you have a PHP version smaller than 5.5.9, you will not be able to send any payload.
+
+If you have a PHP version smaller than 7.1, you will have to `composer require spomky-labs/jose:2.0.x-dev`,
+and if you want to speed things up, install the [PHP Crypto](https://github.com/bukka/php-crypto) extension.
+
 ## Usage
 WebPush can be used to send notifications to endpoints which server delivers web push notifications as described in 
 the [Web Push API specification](http://www.w3.org/TR/push-api/).
@@ -140,7 +145,8 @@ Not until the [Push API spec](http://www.w3.org/TR/push-api/) is finished.
 ### What about security?
 Internally, WebPush uses the [phpecc](https://github.com/phpecc/phpecc) Elliptic Curve Cryptography library to create 
 local public and private keys and compute the shared secret. 
-Then, WebPush uses `openssl` in order to encrypt the payload with the encryption key.
+Then, if you have a PHP >= 7.1, WebPush uses `openssl` in order to encrypt the payload with the encryption key.
+It uses [jose](https://github.com/Spomky-Labs/jose) if you have PHP < 7.1, which is slower.
 
 ### How to solve "SSL certificate problem: unable to get local issuer certificate" ?
 Your installation lacks some certificates.

--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@
 
 If you have a PHP version smaller than 5.5.9, you will not be able to send any payload.
 
-If you have a PHP version smaller than 7.1, you will have to `composer require spomky-labs/jose:2.0.x-dev`,
-and if you want to speed things up, install the [PHP Crypto](https://github.com/bukka/php-crypto) extension.
+If you have a PHP version smaller than 7.1, you will have to `composer require spomky-labs/jose:2.0.x-dev`.
 
 ## Usage
 WebPush can be used to send notifications to endpoints which server delivers web push notifications as described in 
-the [Web Push API specification](http://www.w3.org/TR/push-api/).
+the [Web Push protocol](https://tools.ietf.org/html/draft-thomson-webpush-protocol-00).
 As it is standardized, you don't have to worry about what server type it relies on.
+
+Notifications with payloads are supported with this library on Firefox 47+ and Chrome 50+.
 
 ```php
 <?php
@@ -64,6 +65,12 @@ $webPush->sendNotification(
     true // optional (defaults false)
 );
 ```
+
+### Client side implementation of Web Push
+There are several good examples and tutorials on the web:
+* Mozilla's [ServiceWorker Cookbooks](https://serviceworke.rs/push-payload.html) (outdated as of 03-20-2016, because it does not take into account the user auth secret)
+* Google's [introduction to push notifications](https://developers.google.com/web/fundamentals/getting-started/push-notifications/) (as of 03-20-2016, it doesn't mention notifications with payload)
+* you may take a look at my own implementation: [sw.js](https://github.com/Minishlink/physbook/blob/07433bdb5fe4e3c7a6e4465c74e3b07c5a12886c/web/service-worker.js) and [app.js](https://github.com/Minishlink/physbook/blob/2a468273665a241ddc9aa2e12c57d18cd842d965/app/Resources/public/js/app.js) (payload sent indirectly)
 
 ### GCM servers notes (Chrome)
 For compatibility reasons, this library detects if the server is a GCM server and appropriately sends the notification.
@@ -164,8 +171,11 @@ Feel free to add your own!
 Not until the [Push API spec](http://www.w3.org/TR/push-api/) is finished.
 
 ### What about security?
+Payload is encrypted according to the [Message Encryption for Web Push](https://tools.ietf.org/html/draft-ietf-webpush-encryption-01) standard,
+using the user public key and authentication secret that you can get by following the [Web Push API](http://www.w3.org/TR/push-api/) specification.
+
 Internally, WebPush uses the [phpecc](https://github.com/phpecc/phpecc) Elliptic Curve Cryptography library to create 
-local public and private keys and compute the shared secret. 
+local public and private keys and compute the shared secret.
 Then, if you have a PHP >= 7.1, WebPush uses `openssl` in order to encrypt the payload with the encryption key.
 It uses [jose](https://github.com/Spomky-Labs/jose) if you have PHP < 7.1, which is slower.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 If you have a PHP version smaller than 5.5.9, you will not be able to send any payload.
 
-If you have a PHP version smaller than 7.1, you will have to `composer require spomky-labs/jose:2.0.x-dev`.
-
 ## Usage
 WebPush can be used to send notifications to endpoints which server delivers web push notifications as described in 
 the [Web Push protocol](https://tools.ietf.org/html/draft-thomson-webpush-protocol-00).
@@ -177,7 +175,7 @@ using the user public key and authentication secret that you can get by followin
 Internally, WebPush uses the [phpecc](https://github.com/phpecc/phpecc) Elliptic Curve Cryptography library to create 
 local public and private keys and compute the shared secret.
 Then, if you have a PHP >= 7.1, WebPush uses `openssl` in order to encrypt the payload with the encryption key.
-It uses [jose](https://github.com/Spomky-Labs/jose) if you have PHP < 7.1, which is slower.
+Otherwise, it uses [Spomky-Labs/php-aes-gcm](https://github.com/Spomky-Labs/php-aes-gcm) if you have PHP < 7.1, which is slower.
 
 ### How to solve "SSL certificate problem: unable to get local issuer certificate" ?
 Your installation lacks some certificates.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ WebPush can be used to send notifications to endpoints which server delivers web
 the [Web Push protocol](https://tools.ietf.org/html/draft-thomson-webpush-protocol-00).
 As it is standardized, you don't have to worry about what server type it relies on.
 
-Notifications with payloads are supported with this library on Firefox 47+ and Chrome 50+.
+Notifications with payloads are supported with this library on Firefox 46+ and Chrome 50+.
 
 ```php
 <?php

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 ## Installation
 `composer require minishlink/web-push`
 
-If you have a PHP version smaller than 5.5.9, you will not be able to send any payload.
-
 ## Usage
 WebPush can be used to send notifications to endpoints which server delivers web push notifications as described in 
 the [Web Push protocol](https://tools.ietf.org/html/draft-thomson-webpush-protocol-00).
@@ -175,7 +173,7 @@ using the user public key and authentication secret that you can get by followin
 Internally, WebPush uses the [phpecc](https://github.com/phpecc/phpecc) Elliptic Curve Cryptography library to create 
 local public and private keys and compute the shared secret.
 Then, if you have a PHP >= 7.1, WebPush uses `openssl` in order to encrypt the payload with the encryption key.
-Otherwise, it uses [Spomky-Labs/php-aes-gcm](https://github.com/Spomky-Labs/php-aes-gcm) if you have PHP < 7.1, which is slower.
+Otherwise, if you have PHP < 7.1, it uses [Spomky-Labs/php-aes-gcm](https://github.com/Spomky-Labs/php-aes-gcm), which is slower.
 
 ### How to solve "SSL certificate problem: unable to get local issuer certificate" ?
 Your installation lacks some certificates.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
   "require": {
     "php": ">=5.4",
     "kriswallsmith/buzz": ">=0.6",
-    "mdanter/ecc": "^0.3.0"
+    "mdanter/ecc": "^0.3.0",
+    "lib-openssl": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "php": ">=5.4",
     "kriswallsmith/buzz": ">=0.6",
     "mdanter/ecc": "^0.3.0",
-    "lib-openssl": "*"
+    "lib-openssl": "*",
+    "spomky-labs/base64url": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "minishlink/web-push",
   "type": "library",
   "description": "Web Push library for PHP",
-  "keywords": ["push", "notifications", "web"],
+  "keywords": ["push", "notifications", "web", "WebPush", "Push API"],
   "homepage": "https://github.com/Minishlink/web-push",
   "license": "MIT",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,11 @@
     "kriswallsmith/buzz": ">=0.6",
     "mdanter/ecc": "^0.3.0",
     "lib-openssl": "*",
-    "spomky-labs/base64url": "^1.0"
+    "spomky-labs/base64url": "^1.0",
+    "spomky-labs/php-aes-gcm": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.8.*",
-    "spomky-labs/jose": "2.0.x-dev"
-  },
-  "suggest": {
-    "spomky-labs/jose:2.0.x-dev": "Payload support if you have 5.5.9 <= PHP version < 7.1"
+    "phpunit/phpunit": "4.8.*"
   },
   "autoload": {
     "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "kriswallsmith/buzz": ">=0.6",
     "mdanter/ecc": "^0.3.0",
     "lib-openssl": "*",
-    "spomky-labs/jose": "^0.4.6"
+    "spomky-labs/jose": "2.0.x-dev"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "php": ">=5.4",
     "kriswallsmith/buzz": ">=0.6",
     "mdanter/ecc": "^0.3.0",
-    "lib-openssl": "*"
+    "lib-openssl": "*",
+    "spomky-labs/jose": "^0.4.6"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
   ],
   "require": {
     "php": ">=5.4",
-    "kriswallsmith/buzz": ">=0.6"
+    "kriswallsmith/buzz": ">=0.6",
+    "mdanter/ecc": "^0.3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*"

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,14 @@
     "php": ">=5.4",
     "kriswallsmith/buzz": ">=0.6",
     "mdanter/ecc": "^0.3.0",
-    "lib-openssl": "*",
-    "spomky-labs/jose": "2.0.x-dev"
+    "lib-openssl": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.8.*"
+    "phpunit/phpunit": "4.8.*",
+    "spomky-labs/jose": "2.0.x-dev"
+  },
+  "suggest": {
+    "spomky-labs/jose:2.0.x-dev": "Payload support if you have 5.5.9 <= PHP version < 7.1"
   },
   "autoload": {
     "psr-4" : {

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -18,6 +18,7 @@
         <env name="STANDARD_ENDPOINT" value="" />
         <env name="GCM_ENDPOINT" value="" />
         <env name="USER_PUBLIC_KEY" value="" />
+        <env name="USER_AUTH_TOKEN" value="" />
         <env name="GCM_API_KEY" value="" />
     </php>
 </phpunit>

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -16,9 +16,12 @@
     </testsuites>
     <php>
         <env name="STANDARD_ENDPOINT" value="" />
-        <env name="GCM_ENDPOINT" value="" />
         <env name="USER_PUBLIC_KEY" value="" />
         <env name="USER_AUTH_TOKEN" value="" />
+
+        <env name="GCM_ENDPOINT" value="" />
+        <env name="GCM_USER_PUBLIC_KEY" value="" />
+        <env name="GCM_USER_AUTH_TOKEN" value="" />
         <env name="GCM_API_KEY" value="" />
     </php>
 </phpunit>

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -18,6 +18,17 @@ use Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer;
 
 final class Encryption
 {
+    const MAX_PAYLOAD_LENGTH = 4078;
+
+    /**
+     * @param $payload
+     * @return string
+     */
+    public static function automaticPadding($payload)
+    {
+        return str_pad($payload, self::MAX_PAYLOAD_LENGTH, chr(0), STR_PAD_LEFT);
+    }
+
     /**
      * @param string $payload
      * @param string $userPublicKey MIME base 64 encoded

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -111,7 +111,7 @@ final class Encryption
      *
      * @param $salt string A non-secret random value
      * @param $ikm string Input keying material
-     * @param $info string Application-specfic context
+     * @param $info string Application-specific context
      * @param $length int The length (in bytes) of the required output key
      * @return string
      */
@@ -143,7 +143,7 @@ final class Encryption
 
         // This one should never happen, because it's our code that generates the key
         if (strlen($serverPublicKey) !== 65) {
-        throw new \ErrorException('Invalid server public key length');
+            throw new \ErrorException('Invalid server public key length');
         }
 
         return chr(0).strlen($clientPublicKey).$clientPublicKey.strlen($serverPublicKey).$serverPublicKey;

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -72,8 +72,7 @@ final class Encryption
         $context = self::createContext($userPublicKey, $localPublicKey);
 
         // derive the Content Encryption Key
-        // TODO Chrome GCM wants 'aesgcm'?
-        $contentEncryptionKeyInfo = self::createInfo('aesgcm128', $context);
+        $contentEncryptionKeyInfo = self::createInfo('aesgcm', $context);
         $contentEncryptionKey = self::hkdf($salt, $ikm, $contentEncryptionKeyInfo, 16);
 
         // section 3.3, derive the nonce
@@ -165,7 +164,6 @@ final class Encryption
             throw new \ErrorException('Context argument has invalid size');
         }
 
-        // TODO Why 'P-256'?
         return 'Content-Encoding: '.$type.chr(0).'P-256'.$context;
     }
 }

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -28,7 +28,7 @@ final class Encryption
     {
         $payloadLen = strlen($payload);
         $padLen = $automatic ? self::MAX_PAYLOAD_LENGTH - $payloadLen : 0;
-        return chr($padLen >> 8).chr($padLen & 0xFF).str_pad($payload, $padLen + $payloadLen, chr(0), STR_PAD_LEFT);
+        return pack('n*', $padLen).str_pad($payload, $padLen + $payloadLen, chr(0), STR_PAD_LEFT);
     }
 
     /**

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -82,17 +82,16 @@ final class Encryption
         // encrypt
         // "The additional data passed to each invocation of AEAD_AES_128_GCM is a zero-length octet sequence."
         if (!$nativeEncryption) {
-            list($encryptedText, $tag) = \Jose\Util\GCM::encrypt($contentEncryptionKey, $nonce, $plaintext, null);
-            $cipherText = $encryptedText.$tag;
+            list($encryptedText, $tag) = \Jose\Util\GCM::encrypt($contentEncryptionKey, $nonce, $plaintext, "");
         } else {
-            $cipherText = openssl_encrypt($plaintext, 'aes-128-gcm', $contentEncryptionKey, false, $nonce); // base 64 encoded
+            $encryptedText = openssl_encrypt($plaintext, 'aes-128-gcm', $contentEncryptionKey, OPENSSL_RAW_DATA, $nonce, $tag); // base 64 encoded
         }
 
         // return values in url safe base64
         return array(
             'localPublicKey' => Base64Url::encode($localPublicKey),
             'salt' => Base64Url::encode($salt),
-            'cipherText' => $cipherText,
+            'cipherText' => $encryptedText.$tag,
         );
     }
 

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -84,7 +84,7 @@ final class Encryption
         // encrypt
         // "The additional data passed to each invocation of AEAD_AES_128_GCM is a zero-length octet sequence."
         if (!$nativeEncryption) {
-            list($encryptedText, $tag) = \Jose\Util\GCM::encrypt($contentEncryptionKey, $nonce, $payload, "");
+            list($encryptedText, $tag) = \AESGCM\AESGCM::encrypt($contentEncryptionKey, $nonce, $payload, "");
         } else {
             $encryptedText = openssl_encrypt($payload, 'aes-128-gcm', $contentEncryptionKey, OPENSSL_RAW_DATA, $nonce, $tag); // base 64 encoded
         }

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -26,7 +26,7 @@ class Notification
     {
         $this->endpoint = $endpoint;
         $this->payload = $payload;
-        $this->userPublicKey = $payload;
+        $this->userPublicKey = $userPublicKey;
     }
 
     /**
@@ -35,5 +35,21 @@ class Notification
     public function getEndpoint()
     {
         return $this->endpoint;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getPayload()
+    {
+        return $this->payload;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getUserPublicKey()
+    {
+        return $this->userPublicKey;
     }
 }

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -16,11 +16,21 @@ class Notification
     /** @var string */
     private $endpoint;
 
-    public function __construct($endpoint, $payload, $userPublicKey)
+    /** @var string */
+    private $payload;
+
+    /** @var string */
+    private $userPublicKey;
+
+    /** @var string */
+    private $userAuthToken;
+
+    public function __construct($endpoint, $payload, $userPublicKey, $userAuthToken)
     {
         $this->endpoint = $endpoint;
         $this->payload = $payload;
         $this->userPublicKey = $userPublicKey;
+        $this->userAuthToken = $userAuthToken;
     }
 
     /**
@@ -45,5 +55,13 @@ class Notification
     public function getUserPublicKey()
     {
         return $this->userPublicKey;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getUserAuthToken()
+    {
+        return $this->userAuthToken;
     }
 }

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -82,6 +82,10 @@ class WebPush
             throw new \ErrorException('The API has changed: sendNotification now takes the optional user auth token as parameter.');
         }
 
+        if(isset($payload) && strlen($payload) > 4078) {
+            throw new \ErrorException('Size of payload must not be greater than 4078 octets.');
+        }
+
         // sort notification by server type
         $type = $this->sortEndpoint($endpoint);
         $this->notificationsByServerType[$type][] = new Notification($endpoint, $payload, $userPublicKey, $userAuthToken);

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -19,7 +19,6 @@ use Buzz\Message\Response;
 use Mdanter\Ecc\Crypto\Key\PublicKey;
 use Mdanter\Ecc\EccFactory;
 use Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer;
-use Jose\Util\GCM;
 
 class WebPush
 {
@@ -200,7 +199,7 @@ class WebPush
         // encrypt
         $iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length('aes-128-gcm'));
         if (!$this->nativePayloadEncryptionSupport) {
-            list($encryptedText, $tag) = GCM::encrypt($encryptionKey, $iv, $payload, "");
+            list($encryptedText, $tag) = \Jose\Util\GCM::encrypt($encryptionKey, $iv, $payload, "");
             $cipherText = $encryptedText.$tag;
         } else {
             $cipherText = openssl_encrypt($payload, 'aes-128-gcm', $encryptionKey, false, $iv); // base 64 encoded

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -62,7 +62,7 @@ class WebPush
         $client->setTimeout($timeout);
         $this->browser = new Browser($client);
 
-        $this->payloadEncryptionSupport = version_compare(phpversion(), '5.5.9', '>=');
+        $this->payloadEncryptionSupport = version_compare(phpversion(), '5.5.9', '>=') && class_exists("\\Jose\\Util\\GCM");
         $this->nativePayloadEncryptionSupport = version_compare(phpversion(), '7.1', '>=');
     }
 
@@ -220,7 +220,7 @@ class WebPush
             $payload = $notification->getPayload();
             $userPublicKey = $notification->getUserPublicKey();
 
-            if (isset($payload) && isset($userPublicKey) && $this->payloadEncryptionSupport) {
+            if (isset($payload) && isset($userPublicKey) && ($this->payloadEncryptionSupport || $this->nativePayloadEncryptionSupport)) {
                 $encrypted = $this->encrypt($userPublicKey, $payload);
 
                 $headers = array(

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -209,7 +209,7 @@ class WebPush
 
         // encrypt
         $iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length('aes-128-gcm'));
-        if (!$this->nativePayloadEncryptionSupport) {
+        if (!$this->nativePayloadEncryptionSupport && $this->payloadEncryptionSupport) {
             list($encryptedText, $tag) = \Jose\Util\GCM::encrypt($encryptionKey, $iv, $payload, "");
             $cipherText = $encryptedText.$tag;
         } else {

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -195,9 +195,10 @@ class WebPush
             $endpoint = $notification->getEndpoint();
             $payload = $notification->getPayload();
             $userPublicKey = $notification->getUserPublicKey();
+            $userAuthToken = $notification->getUserAuthToken();
 
-            if (isset($payload) && isset($userPublicKey) && ($this->payloadEncryptionSupport || $this->nativePayloadEncryptionSupport)) {
-                $encrypted = Encryption::encrypt($payload, $userPublicKey, $notification->getUserAuthToken(), $this->nativePayloadEncryptionSupport);
+            if (isset($payload) && isset($userPublicKey) && isset($userAuthToken) && ($this->payloadEncryptionSupport || $this->nativePayloadEncryptionSupport)) {
+                $encrypted = Encryption::encrypt($payload, $userPublicKey, $userAuthToken, $this->nativePayloadEncryptionSupport);
 
                 $headers = array(
                     'Content-Length' => strlen($encrypted['cipherText']),

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -93,9 +93,7 @@ class WebPush
                 throw new \ErrorException('Size of payload must not be greater than '.Encryption::MAX_PAYLOAD_LENGTH.' octets.');
             }
 
-            if ($this->automaticPadding) {
-                $payload = Encryption::automaticPadding($payload);
-            }
+            $payload = Encryption::padPayload($payload, $this->automaticPadding);
         }
 
         // sort notification by server type

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -135,8 +135,6 @@ class WebPush
      * @param string $payload
      *
      * @return array
-     *
-     * @throws
      */
     private function encrypt($userPublicKey, $payload)
     {
@@ -158,7 +156,7 @@ class WebPush
         $sharedSecret = $userPublicKeyObject->getPoint()->mul($localPrivateKeyObject->getSecret())->getX();
 
         // generate salt
-        $salt = base64_encode(openssl_random_pseudo_bytes(16));
+        $salt = openssl_random_pseudo_bytes(16);
 
         // get encryption key
         $encryptionKey = hash_hmac('sha256', $salt, $sharedSecret);
@@ -169,7 +167,7 @@ class WebPush
 
         return array(
             'localPublicKey' => $localPublicKey,
-            'salt' => $salt,
+            'salt' => base64_encode($salt),
             'cipherText' => $cipherText,
         );
     }

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -196,7 +196,7 @@ class WebPush
                 $headers = array(
                     'Content-Length' => strlen($encrypted['cipherText']),
                     'Content-Type' => 'application/octet-stream',
-                    'Content-Encoding' => 'aesgcm',
+                    'Content-Encoding' => 'aesgcm128',
                     'Encryption' => 'keyid="p256dh";salt="'.$encrypted['salt'].'"',
                     'Crypto-Key' => 'keyid="p256dh";dh="'.$encrypted['localPublicKey'].'"',
                     'TTL' => $this->TTL,

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -19,6 +19,7 @@ use Buzz\Message\Response;
 use Mdanter\Ecc\Crypto\Key\PublicKey;
 use Mdanter\Ecc\EccFactory;
 use Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer;
+use Jose\Util\GCM;
 
 class WebPush
 {
@@ -189,7 +190,12 @@ class WebPush
 
         // encrypt
         $iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length('aes-128-gcm'));
-        $cipherText = openssl_encrypt($payload, 'aes-128-gcm', $encryptionKey, false, $iv); // base 64 encoded
+        if (phpversion() < 7.1) {
+            list($encryptedText, $tag) = GCM::encrypt($encryptionKey, $iv, $payload, "");
+            $cipherText = $encryptedText.$tag;
+        } else {
+            $cipherText = openssl_encrypt($payload, 'aes-128-gcm', $encryptionKey, false, $iv); // base 64 encoded
+        }
 
         return array(
             'localPublicKey' => $localPublicKey,

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -187,23 +187,16 @@ class WebPush
         );
     }
 
-    /**
-     * @param array      $endpoints
-     * @param array|null $payloads
-     * @param array|null $userPublicKeys
-     *
-     * @return array
-     *
-     * @throws \ErrorException
-     */
     private function sendToStandardEndpoints(array $notifications)
     {
         $responses = array();
-        foreach ($endpoints as $i => $endpoint) {
-            $payload = $payloads[$i];
+        /** @var Notification $notification */
+        foreach ($notifications as $notification) {
+            $payload = $notification->getPayload();
+            $userPublicKey = $notification->getUserPublicKey();
 
-            if (isset($payload)) {
-                $encrypted = $this->encrypt($userPublicKeys[$i], $payload);
+            if (isset($payload) && isset($userPublicKey)) {
+                $encrypted = $this->encrypt($userPublicKey, $payload);
 
                 $headers = array(
                     'Content-Length' => strlen($encrypted['cipherText']),
@@ -226,9 +219,6 @@ class WebPush
                 $headers['TTL'] = $this->TTL;
             }
 
-        $responses = array();
-        /** @var Notification $notification */
-        foreach ($notifications as $notification) {
             $responses[] = $this->sendRequest($notification->getEndpoint(), $headers, $content);
         }
 

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -74,7 +74,7 @@ class WebPush
      * @param string|null $userPublicKey
      * @param bool        $flush If you want to flush directly (usually when you send only one notification)
      *
-     * @return bool|array Return an array of information if $flush is set to true and the request has failed.
+     * @return bool|array Return an array of information if $flush is set to true and the queued requests has failed.
      *                    Else return true.
      * @throws \ErrorException
      */
@@ -86,7 +86,18 @@ class WebPush
 
         if ($flush) {
             $res = $this->flush();
-            return is_array($res) ? $res[0] : true;
+
+            // if there has been a problem with at least one notification
+            if (is_array($res)) {
+                // if there was only one notification, return the informations directly
+                if (count($res) === 1) {
+                    return $res[0];
+                }
+
+                return $res;
+            }
+
+            return true;
         }
 
         return true;

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -16,8 +16,9 @@ use Buzz\Client\AbstractClient;
 use Buzz\Client\MultiCurl;
 use Buzz\Exception\RequestException;
 use Buzz\Message\Response;
+use Mdanter\Ecc\Crypto\Key\PublicKey;
 use Mdanter\Ecc\EccFactory;
-use Mdanter\Ecc\Message\MessageFactory;
+use Mdanter\Ecc\Serializer\Point\UncompressedPointSerializer;
 
 class WebPush
 {
@@ -139,35 +140,37 @@ class WebPush
      */
     private function encrypt($userPublicKey, $payload)
     {
-        throw new \ErrorException('Encryption does not work yet.');
+        // initialize utilities
+        $math = EccFactory::getAdapter();
+        $keySerializer = new UncompressedPointSerializer($math);
+        $curveGenerator = EccFactory::getNistCurves()->generator256();
+        $curve = EccFactory::getNistCurves()->curve256();
 
-        // get local curve
-        $localCurveGenerator = EccFactory::getNistCurves()->generator256();
-        $localPrivateKey = $localCurveGenerator->createPrivateKey();
-        $localPublicKey = $localPrivateKey->getPublicKey();
-        // var sharedSecret = localCurve.computeSecret(userPublicKey);
+        // get local key pair
+        $localPrivateKeyObject = $curveGenerator->createPrivateKey();
+        $localPublicKeyObject = $localPrivateKeyObject->getPublicKey();
+        $localPublicKey = base64_encode(hex2bin($keySerializer->serialize($localPublicKeyObject->getPoint())));
 
-        //var salt = crypto.randomBytes(16);
+        // get user public key object
+        $userPublicKeyObject = new PublicKey($math, $curveGenerator, $keySerializer->unserialize($curve, bin2hex(base64_decode($userPublicKey))));
 
-        //ece.saveKey('webpushKey', sharedSecret);
+        // get shared secret from user public key and local private key
+        $sharedSecret = $userPublicKeyObject->getPoint()->mul($localPrivateKeyObject->getSecret())->getX();
 
-        /*var cipherText = ece.encrypt(payload, {
-            keyid: 'webpushKey',
-            salt: urlBase64.encode(salt),
-        });*/
+        // generate salt
+        $salt = base64_encode(openssl_random_pseudo_bytes(16));
 
-        $messages = new MessageFactory(EccFactory::getAdapter());
-        $message = $messages->plaintext($payload, 'sha256');
+        // get encryption key
+        $encryptionKey = hash_hmac('sha256', $salt, $sharedSecret);
 
-        $dh = $localPrivateKey->createExchange($messages, $userPublicKey);
-        $salt = hash('sha256', $dh->calculateSharedKey(), true);
-
-        $cipherText = $dh->encrypt($message)->getContent();
+        // encrypt
+        $iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length('aes-128-gcm'));
+        $cipherText = openssl_encrypt($payload, 'aes-128-gcm', $encryptionKey, false, $iv); // base 64 encoded
 
         return array(
-            'localPublicKey' => base64_encode($localPublicKey),
-            'salt' => base64_encode($salt),
-            'cipherText' => base64_encode($cipherText),
+            'localPublicKey' => $localPublicKey,
+            'salt' => $salt,
+            'cipherText' => $cipherText,
         );
     }
 

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -43,9 +43,6 @@ class WebPush
     private $automaticPadding = true;
 
     /** @var boolean */
-    private $payloadEncryptionSupport;
-
-    /** @var boolean */
     private $nativePayloadEncryptionSupport;
 
     /**
@@ -64,8 +61,7 @@ class WebPush
         $client = isset($client) ? $client : new MultiCurl();
         $client->setTimeout($timeout);
         $this->browser = new Browser($client);
-
-        $this->payloadEncryptionSupport = version_compare(phpversion(), '5.5.9', '>=') && class_exists("\\Jose\\Util\\GCM");
+        
         $this->nativePayloadEncryptionSupport = version_compare(phpversion(), '7.1', '>=');
     }
 
@@ -195,7 +191,7 @@ class WebPush
             $userPublicKey = $notification->getUserPublicKey();
             $userAuthToken = $notification->getUserAuthToken();
 
-            if (isset($payload) && isset($userPublicKey) && isset($userAuthToken) && ($this->payloadEncryptionSupport || $this->nativePayloadEncryptionSupport)) {
+            if (isset($payload) && isset($userPublicKey) && isset($userAuthToken)) {
                 $encrypted = Encryption::encrypt($payload, $userPublicKey, $userAuthToken, $this->nativePayloadEncryptionSupport);
 
                 $headers = array(

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -18,12 +18,12 @@ class EncryptionTest extends PHPUnit_Framework_TestCase
      *
      * @param string $payload
      */
-    public function testAutomaticPadding($payload)
+    public function testPadPayload($payload)
     {
-        $res = Encryption::automaticPadding($payload);
+        $res = Encryption::padPayload($payload, true);
 
         $this->assertContains('test', $res);
-        $this->assertEquals(4078, strlen($res));
+        $this->assertEquals(4080, strlen($res));
     }
 
     public function payloadProvider()

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the WebPush library.
+ *
+ * (c) Louis Lagrange <lagrange.louis@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Minishlink\WebPush\Encryption;
+
+class EncryptionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider payloadProvider
+     *
+     * @param string $payload
+     */
+    public function testAutomaticPadding($payload)
+    {
+        $res = Encryption::automaticPadding($payload);
+
+        $this->assertContains('test', $res);
+        $this->assertEquals(4078, strlen($res));
+    }
+
+    public function payloadProvider()
+    {
+        return array(
+            array('test'),
+            array(str_repeat('test', 1019)),
+            array(str_repeat('test', 1019).'te'),
+        );
+    }
+}

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -91,17 +91,13 @@ class WebPushTest extends PHPUnit_Framework_TestCase
         $encrypt = $class->getMethod('encrypt');
         $encrypt->setAccessible(true);
 
-        $expected = array(
-            'localPublicKey' => 'BH_1HZcs53fCIMW7Q6ePJqCqc4JIzSeCTjcNBmoet2eMObvQTpiBHH0EnDYZ0kTqk5f2b6wruq7US1vewtngt6o',
-            'salt' => '0HK6QfkQmcQKFVAgG2iOTw',
-            'cipherText' => 'ivmuewrVd-7qkRgxRcu972JyrSvXJzbLeWhTXx1FRZndeP5PVS3fnLQhmK077PgW7C5MLAA_wzDpIN_oB9vo',
-        );
+        $res = $encrypt->invokeArgs($this->webPush, array($this->keys['standard'], 'test'));
 
-        $actualUserPublicKey = 'BDFsuXPNuJ4SxoYcVVvRagonMcSKHXjsif4qmzpXTDyy29ZKqbwtVAgHCLJGP0HgQ0hpkg6H5-fPBvDjBQxjYfc';
-        $actualPayload = '{"action":"chatMsg","name":"Bob","msg":"test"}';
-
-        $actual = $encrypt->invokeArgs($this->webPush, array($actualUserPublicKey, $actualPayload));
-
-        $this->assertEquals($expected, $actual);
+        // I can't really test encryption since I don't have the user private key.
+        // I can only test if the function executes.
+        $this->assertArrayHasKey('cipherText', $res);
+        $this->assertArrayHasKey('salt', $res);
+        $this->assertArrayHasKey('localPublicKey', $res);
+        $this->assertEquals(16, strlen(base64_decode($res['salt']))); // should be 16 bytes
     }
 }

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -37,6 +37,7 @@ class WebPushTest extends PHPUnit_Framework_TestCase
         );
 
         $this->webPush = new WebPush($this->keys);
+        $this->webPush->setAutomaticPadding(false); // disable automatic padding in tests to speed these up
     }
 
     public function testSendNotification()
@@ -63,7 +64,7 @@ class WebPushTest extends PHPUnit_Framework_TestCase
     {
         $res = $this->webPush->sendNotification(
             $this->endpoints['standard'],
-            'test',
+            '{message: "Plop", tag: "general"}',
             $this->keys['standard'],
             null,
             true

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -15,6 +15,7 @@ class WebPushTest extends PHPUnit_Framework_TestCase
 {
     private $endpoints;
     private $keys;
+    private $tokens;
 
     /** @var WebPush WebPush with correct api keys */
     private $webPush;
@@ -31,12 +32,16 @@ class WebPushTest extends PHPUnit_Framework_TestCase
             'GCM' => getenv('GCM_API_KEY'),
         );
 
+        $this->tokens = array(
+            'standard' => getenv('USER_AUTH_TOKEN'),
+        );
+
         $this->webPush = new WebPush($this->keys);
     }
 
     public function testSendNotification()
     {
-        $res = $this->webPush->sendNotification($this->endpoints['standard'], null, null, true);
+        $res = $this->webPush->sendNotification($this->endpoints['standard'], null, null, null, true);
 
         $this->assertEquals($res, true);
     }
@@ -47,10 +52,35 @@ class WebPushTest extends PHPUnit_Framework_TestCase
             $this->endpoints['standard'],
             'test',
             $this->keys['standard'],
+            $this->tokens['standard'],
             true
         );
 
         $this->assertTrue($res);
+    }
+
+    public function testSendNotificationWithPayloadWithoutAuthToken()
+    {
+        $res = $this->webPush->sendNotification(
+            $this->endpoints['standard'],
+            'test',
+            $this->keys['standard'],
+            null,
+            true
+        );
+
+        $this->assertTrue($res);
+    }
+
+    public function testSendNotificationWithOldAPI()
+    {
+        $this->setExpectedException('ErrorException', 'The API has changed: sendNotification now takes the optional user auth token as parameter.');
+        $this->webPush->sendNotification(
+            $this->endpoints['standard'],
+            'test',
+            $this->keys['standard'],
+            true
+        );
     }
 
     public function testSendNotifications()
@@ -81,14 +111,14 @@ class WebPushTest extends PHPUnit_Framework_TestCase
         $webPush = new WebPush();
 
         $this->setExpectedException('ErrorException', 'No GCM API Key specified.');
-        $webPush->sendNotification($this->endpoints['GCM'], null, null, true);
+        $webPush->sendNotification($this->endpoints['GCM'], null, null, null, true);
     }
 
     public function testSendGCMNotificationWithWrongGCMApiKey()
     {
         $webPush = new WebPush(array('GCM' => 'bar'));
 
-        $res = $webPush->sendNotification($this->endpoints['GCM'], null, null, true);
+        $res = $webPush->sendNotification($this->endpoints['GCM'], null, null, null, true);
 
         $this->assertTrue(is_array($res)); // there has been an error
         $this->assertArrayHasKey('success', $res);

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -49,9 +49,9 @@ class WebPushTest extends PHPUnit_Framework_TestCase
         self::setUpBeforeClass(); // dirty hack of PHPUnit limitation
         return array(
             array(self::$endpoints['standard'], null, null, null),
-            array(self::$endpoints['standard'], '{"message":"Plop","tag":"general"}', self::$keys['standard'], self::$tokens['standard']),
+            array(self::$endpoints['standard'], '{"message":"Comment ça va ?","tag":"general"}', self::$keys['standard'], self::$tokens['standard']),
             array(self::$endpoints['GCM'], null, null, null),
-            array(self::$endpoints['GCM'], '{"message":"Plop","tag":"general"}', self::$keys['GCM'], self::$tokens['GCM']),
+            array(self::$endpoints['GCM'], '{"message":"Comment ça va ?","tag":"general"}', self::$keys['GCM'], self::$tokens['GCM']),
         );
     }
 

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -42,6 +42,18 @@ class WebPushTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(true, $res['success']);
     }
 
+    public function testSendNotificationWithPayload()
+    {
+        $res = $this->webPush->sendNotification(
+            $this->endpoints['standard'],
+            'test',
+            $this->keys['standard']
+        );
+
+        $this->assertArrayHasKey('success', $res);
+        $this->assertEquals(true, $res['success']);
+    }
+
     public function testSendGCMNotification()
     {
         $res = $this->webPush->sendNotification($this->endpoints['GCM']);
@@ -70,5 +82,26 @@ class WebPushTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(401, $res['statusCode']);
 
         $this->assertArrayHasKey('headers', $res);
+    }
+
+    public function testEncrypt()
+    {
+        // encrypt is a private method
+        $class = new ReflectionClass(get_class($this->webPush));
+        $encrypt = $class->getMethod('encrypt');
+        $encrypt->setAccessible(true);
+
+        $expected = array(
+            'localPublicKey' => 'BH_1HZcs53fCIMW7Q6ePJqCqc4JIzSeCTjcNBmoet2eMObvQTpiBHH0EnDYZ0kTqk5f2b6wruq7US1vewtngt6o',
+            'salt' => '0HK6QfkQmcQKFVAgG2iOTw',
+            'cipherText' => 'ivmuewrVd-7qkRgxRcu972JyrSvXJzbLeWhTXx1FRZndeP5PVS3fnLQhmK077PgW7C5MLAA_wzDpIN_oB9vo',
+        );
+
+        $actualUserPublicKey = 'BDFsuXPNuJ4SxoYcVVvRagonMcSKHXjsif4qmzpXTDyy29ZKqbwtVAgHCLJGP0HgQ0hpkg6H5-fPBvDjBQxjYfc';
+        $actualPayload = '{"action":"chatMsg","name":"Bob","msg":"test"}';
+
+        $actual = $encrypt->invokeArgs($this->webPush, array($actualUserPublicKey, $actualPayload));
+
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -19,6 +19,19 @@ class WebPushTest extends PHPUnit_Framework_TestCase
 
     /** @var WebPush WebPush with correct api keys */
     private $webPush;
+
+    protected function checkRequirements()
+    {
+        parent::checkRequirements();
+
+        if (!array_key_exists('skipIfTravis', $this->getAnnotations()['method'])) {
+            return;
+        }
+
+        if (getenv('TRAVIS') === true) {
+            $this->markTestSkipped('This test does not run on Travis.');
+        }
+    }
     
     public static function setUpBeforeClass()
     {
@@ -57,6 +70,7 @@ class WebPushTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider notificationProvider
+     * @skipIfTravis
      *
      * @param string $endpoint
      * @param string $payload
@@ -93,6 +107,9 @@ class WebPushTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /*
+     * @skipIfTravis
+     */
     public function testFlush()
     {
         $this->webPush->sendNotification(self::$endpoints['standard']);
@@ -113,6 +130,9 @@ class WebPushTest extends PHPUnit_Framework_TestCase
         $webPush->sendNotification(self::$endpoints['GCM'], null, null, null, true);
     }
 
+    /*
+     * @skipIfTravis
+     */
     public function testSendGCMNotificationWithWrongGCMApiKey()
     {
         $webPush = new WebPush(array('GCM' => 'bar'));

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -129,21 +129,4 @@ class WebPushTest extends PHPUnit_Framework_TestCase
 
         $this->assertArrayHasKey('headers', $res);
     }
-
-    public function testEncrypt()
-    {
-        // encrypt is a private method
-        $class = new ReflectionClass(get_class($this->webPush));
-        $encrypt = $class->getMethod('encrypt');
-        $encrypt->setAccessible(true);
-
-        $res = $encrypt->invokeArgs($this->webPush, array($this->keys['standard'], 'test'));
-
-        // I can't really test encryption since I don't have the user private key.
-        // I can only test if the function executes.
-        $this->assertArrayHasKey('cipherText', $res);
-        $this->assertArrayHasKey('salt', $res);
-        $this->assertArrayHasKey('localPublicKey', $res);
-        $this->assertEquals(16, strlen(base64_decode($res['salt']))); // should be 16 bytes
-    }
 }

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -86,7 +86,7 @@ class WebPushTest extends PHPUnit_Framework_TestCase
 
     public function testSendNotificationWithOldAPI()
     {
-        $this->setExpectedException('ErrorException', 'The API has changed: sendNotification now takes the user auth token as parameter.');
+        $this->setExpectedException('ErrorException', 'The API has changed: sendNotification now takes the optional user auth token as parameter.');
         $this->webPush->sendNotification(
             self::$endpoints['standard'],
             'test',
@@ -107,7 +107,7 @@ class WebPushTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /*
+    /**
      * @skipIfTravis
      */
     public function testFlush()
@@ -130,7 +130,7 @@ class WebPushTest extends PHPUnit_Framework_TestCase
         $webPush->sendNotification(self::$endpoints['GCM'], null, null, null, true);
     }
 
-    /*
+    /**
      * @skipIfTravis
      */
     public function testSendGCMNotificationWithWrongGCMApiKey()

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -28,7 +28,7 @@ class WebPushTest extends PHPUnit_Framework_TestCase
             return;
         }
 
-        if (getenv('TRAVIS') === true) {
+        if (getenv('TRAVIS') || getenv('CI')) {
             $this->markTestSkipped('This test does not run on Travis.');
         }
     }

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -49,11 +49,9 @@ class WebPushTest extends PHPUnit_Framework_TestCase
         self::setUpBeforeClass(); // dirty hack of PHPUnit limitation
         return array(
             array(self::$endpoints['standard'], null, null, null),
-            array(self::$endpoints['standard'], '{message: "Plop", tag: "general"}', self::$keys['standard'], self::$tokens['standard']),
-            array(self::$endpoints['standard'], '{message: "Plop", tag: "general"}', self::$keys['standard'], null),
+            array(self::$endpoints['standard'], '{"message":"Plop","tag":"general"}', self::$keys['standard'], self::$tokens['standard']),
             array(self::$endpoints['GCM'], null, null, null),
-            array(self::$endpoints['GCM'], '{message: "Plop", tag: "general"}', self::$keys['GCM'], self::$tokens['GCM']),
-            array(self::$endpoints['GCM'], '{message: "Plop", tag: "general"}', self::$keys['GCM'], null),
+            array(self::$endpoints['GCM'], '{"message":"Plop","tag":"general"}', self::$keys['GCM'], self::$tokens['GCM']),
         );
     }
 
@@ -74,7 +72,7 @@ class WebPushTest extends PHPUnit_Framework_TestCase
 
     public function testSendNotificationWithOldAPI()
     {
-        $this->setExpectedException('ErrorException', 'The API has changed: sendNotification now takes the optional user auth token as parameter.');
+        $this->setExpectedException('ErrorException', 'The API has changed: sendNotification now takes the user auth token as parameter.');
         $this->webPush->sendNotification(
             self::$endpoints['standard'],
             'test',

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -83,6 +83,18 @@ class WebPushTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testSendNotificationWithTooBigPayload()
+    {
+        $this->setExpectedException('ErrorException', 'Size of payload must not be greater than 4078 octets.');
+        $this->webPush->sendNotification(
+            $this->endpoints['standard'],
+            str_repeat('test', 1020),
+            $this->keys['standard'],
+            null,
+            true
+        );
+    }
+
     public function testSendNotifications()
     {
         foreach($this->endpoints as $endpoint) {

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -126,7 +126,7 @@ class WebPushTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($res['success']);
 
         $this->assertArrayHasKey('statusCode', $res);
-        $this->assertEquals(401, $res['statusCode']);
+        $this->assertEquals(400, $res['statusCode']);
 
         $this->assertArrayHasKey('headers', $res);
     }


### PR DESCRIPTION
- (done) use [phpecc/phpecc](https://github.com/phpecc/phpecc) in order to generate the encryption key in prime256v1
- when [this PHP bug](https://bugs.php.net/bug.php?id=61204) is fixed, replace phpecc by the PHP binding of OpenSSL (thanks @marco-c)
- use OpenSSL with AES 128 GCM mode to encrypt the payload (need to wait for the resolution of [this other PHP bug](https://bugs.php.net/bug.php?id=67304).)

If you want to help: (thanks!)
- vote for the PHP bugs in the above linked pages
- or contribute to [php/php-src](https://github.com/php/php-src) in order to fix the bugs
