### PR TITLE
 openssl_encrypt() expects at most 5 parameters, 6 given

### DIFF
--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -86,7 +86,7 @@ final class Encryption
         if (!$nativeEncryption) {
             list($encryptedText, $tag) = \Jose\Util\GCM::encrypt($contentEncryptionKey, $nonce, $payload, "");
         } else {
-            $encryptedText = openssl_encrypt($payload, 'aes-128-gcm', $contentEncryptionKey, OPENSSL_RAW_DATA, $nonce, $tag); // base 64 encoded
+            $encryptedText = openssl_encrypt($payload, 'aes-128-gcm', $contentEncryptionKey, OPENSSL_RAW_DATA, $nonce); // base 64 encoded
         }
 
         // return values in url safe base64


### PR DESCRIPTION
Like documentation, openssl_encrypt only receives 5 parameters: http://php.net/manual/en/function.openssl-encrypt.php
