### PR TITLE
WIP downgrade phpecc min requirement to 0.3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   ],
   "require": {
     "php": ">=5.6",
-    "mdanter/ecc": "^0.4.0",
+    "mdanter/ecc": "^0.3.0",
     "lib-openssl": "*",
     "spomky-labs/base64url": "^1.0",
     "spomky-labs/php-aes-gcm": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   ],
   "require": {
-    "php": ">=5.6",
+    "php": "^5.4 || ^7.0",
     "mdanter/ecc": "^0.3.0",
     "lib-openssl": "*",
     "spomky-labs/base64url": "^1.0",


### PR DESCRIPTION
**dont merge yet**, I am just testing (using travis) what problems will occur with 0.3.x