### PR TITLE
Bump web push testing service version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - nvm install node
 
 install:
-  - npm install web-push-testing-service@0.3.1 -g
+  - npm install web-push-testing-service@0.3.2 -g
 
 before_script:
   - composer install --prefer-source -n


### PR DESCRIPTION
Sorry I broke your tests again.

I've pinned the versions of selenium-assistant and geckodriver in web-push-testing-service which has been causing me a wide range of headaches at the moment.

This change should give you some more stability.