### PR TITLE
Key Creation Improvement

### DIFF
--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -202,7 +202,6 @@ class Encryption
         return [
             $curve->createPublicKey($privateKey),
             $privateKey,
-
         ];
     }
 
@@ -229,6 +228,6 @@ class Encryption
                 gmp_init(bin2hex($details['ec']['y']), 16)
             )),
             PrivateKey::create(gmp_init(bin2hex($details['ec']['d']), 16))
-            ];
+        ];
     }
 }

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -52,6 +52,8 @@ class Encryption
         $userPublicKey = Base64Url::decode($userPublicKey);
         $userAuthToken = Base64Url::decode($userAuthToken);
 
+        $curve = NistCurve::curve256();
+
         // get local key pair
         list($localPublicKeyObject, $localPrivateKeyObject) = self::createLocalKey();
         $localPublicKey = hex2bin(Utils::serializePublicKey($localPublicKeyObject));
@@ -64,7 +66,7 @@ class Encryption
         );
 
         // get shared secret from user public key and local private key
-        $sharedSecret = (NistCurve::curve256())->mul($userPublicKeyObject->getPoint(), $localPrivateKeyObject->getSecret())->getX();
+        $sharedSecret = $curve->mul($userPublicKeyObject->getPoint(), $localPrivateKeyObject->getSecret())->getX();
         $sharedSecret = hex2bin(gmp_strval($sharedSecret, 16));
 
         // generate salt


### PR DESCRIPTION
This PR allows the creation of the local key using OpenSSL.
If OpenSSL does not support EC key, the pure PHP method is used a a fallback.