### PR TITLE
Return results as a \Generator

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,14 +2,27 @@
 WebPush is an open source library.
 Feel free to contribute by submitting a pull request or creating (and solving) issues!
 
-## Running Tests
+## Installing a mock push service
 
-First, you will need to create your own configuration file by copying
-phpunit.dist.xml to phpunit.xml and filling in the fields you need for
+Before running tests, you'll need to install the [web-push testing service](https://www.npmjs.com/package/web-push-testing-service):
+
+```bash
+npm install web-push-testing-service -g
+```
+
+NOTE: You might need to make sure command `web-push-testing-service` runs OK on cli. In my case on OSX, I needed to add a bash alias after install:
+
+```~/.bash_profile
+alias web-push-testing-service='/usr/local/Cellar/node/7.4.0/bin/web-push-testing-service'
+```
+
+After that, please create your own configuration file by copying
+`phpunit.dist.xml` to phpunit.xml and filling in the fields you need for
 testing (i.e. STANDARD_ENDPOINT, GCM_API_KEY etc.).
 
-Then, download [phpunit](https://phpunit.de/) and test with one of the
-following commands:
+## Running Tests
+
+Then, download [phpunit](https://phpunit.de/) and test with one of the following commands:
 
 **For All Tests**
     `php phpunit.phar`

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ phpunit.xml
 # web-push-testing-service logs
 cli.log
 module.log
+.vagrant
+Vagrantfile # temp, may be?

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 composer.lock
 phpunit.xml
 
+# web-push-testing-service logs
+cli.log
+module.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ sudo: required
 cache:
   directories:
     - ~/.selenium-assistant
+    - node_modules                  # cache modules too
+    - $HOME/.composer/cache/files   # and composer packages
 
 matrix:
     allow_failures:

--- a/README.md
+++ b/README.md
@@ -68,10 +68,26 @@ foreach ($notifications as $notification) {
         $notification['payload'] // optional (defaults null)
     );
 }
-$webPush->flush();
 
-// send one notification and flush directly
-$webPush->sendNotification(
+/**
+ * Check sent results
+ * @var MessageSentReport $report
+ */
+foreach ($webPush->flush() as $report) {
+    $endpoint = $report->getRequest()->getUri()->__toString();
+
+    if ($report->isSuccess()) {
+        echo "[v] Message sent successfully for subscription {$endpoint}.";
+    } else {
+        echo "[x] Message failed to sent for subscription {$endpoint}: {$report->getReason()}";
+    }
+}
+
+/**
+ * send one notification and flush directly
+ * @var \Generator<MessageSentReport> $sent
+ */
+$sent = $webPush->sendNotification(
     $notifications[0]['subscription'],
     $notifications[0]['payload'], // optional (defaults null)
     true // optional (defaults false)

--- a/src/MessageSentReport.php
+++ b/src/MessageSentReport.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * @author Igor Timoshenkov [it@campoint.net]
+ * @started: 03.09.2018 9:21
+ */
+
+namespace Minishlink\WebPush;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Standardized response from sending a message
+ */
+class MessageSentReport {
+
+	/**
+	 * @var boolean
+	 */
+	protected $success;
+
+	/**
+	 * @var RequestInterface
+	 */
+	protected $request;
+
+	/**
+	 * @var ResponseInterface
+	 */
+	protected $response;
+
+	/**
+	 * @var string
+	 */
+	protected $reason;
+
+	/**
+	 * @param RequestInterface  $request
+	 * @param ResponseInterface $response
+	 * @param bool              $success
+	 * @param string            $reason
+	 */
+	public function __construct(?RequestInterface $request = null, ?ResponseInterface $response = null, bool $success = true, $reason = 'OK') {
+		$this->success  = $success;
+		$this->request  = $request;
+		$this->response = $response;
+		$this->reason   = $reason;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isSuccess(): bool {
+		return $this->success;
+	}
+
+	/**
+	 * @param bool $success
+	 *
+	 * @return MessageSentReport
+	 */
+	public function setSuccess(bool $success): MessageSentReport {
+		$this->success = $success;
+		return $this;
+	}
+
+	/**
+	 * @return RequestInterface
+	 */
+	public function getRequest(): RequestInterface {
+		return $this->request;
+	}
+
+	/**
+	 * @param RequestInterface $request
+	 *
+	 * @return MessageSentReport
+	 */
+	public function setRequest(RequestInterface $request): MessageSentReport {
+		$this->request = $request;
+		return $this;
+	}
+
+	/**
+	 * @return ResponseInterface
+	 */
+	public function getResponse(): ResponseInterface {
+		return $this->response;
+	}
+
+	/**
+	 * @param ResponseInterface $response
+	 *
+	 * @return MessageSentReport
+	 */
+	public function setResponse(ResponseInterface $response): MessageSentReport {
+		$this->response = $response;
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getEndpoint(): string {
+		return $this->request->getUri()->__toString();
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isSubscriptionExpired(): bool {
+		return \in_array($this->response->getStatusCode(), [404, 410], true);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getReason(): string {
+		return $this->reason;
+	}
+
+	/**
+	 * @param string $reason
+	 *
+	 * @return MessageSentReport
+	 */
+	public function setReason(string $reason): MessageSentReport {
+		$this->reason = $reason;
+		return $this;
+	}
+}

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -129,10 +129,10 @@ class WebPush
 	 *
 	 * @param null|int $batchSize Defaults the value defined in defaultOptions during instantiation (which defaults to 1000).
 	 *
-	 * @return \iterable
+	 * @return iterable
 	 * @throws \ErrorException
 	 */
-    public function flush(?int $batchSize = null) : \iterable
+    public function flush(?int $batchSize = null) : iterable
     {
         if (empty($this->notifications)) {
 	        yield from [];

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -129,10 +129,10 @@ class WebPush
 	 *
 	 * @param null|int $batchSize Defaults the value defined in defaultOptions during instantiation (which defaults to 1000).
 	 *
-	 * @return \Generator
+	 * @return \iterable
 	 * @throws \ErrorException
 	 */
-    public function flush(?int $batchSize = null) : \Generator
+    public function flush(?int $batchSize = null) : \iterable
     {
         if (empty($this->notifications)) {
 	        yield from [];

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -17,7 +17,7 @@ use Base64Url\Base64Url;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Promise;
+use Psr\Http\Message\ResponseInterface;
 
 class WebPush
 {
@@ -140,17 +140,14 @@ class WebPush
         return true;
     }
 
-    /**
-     * Flush notifications. Triggers the requests.
-     *
-     * @param null|int $batchSize Defaults the value defined in defaultOptions during instantiation (which defaults to 1000).
-     *
-     * @return array|bool If there are no errors, return true.
-     *                    If there were no notifications in the queue, return false.
-     * Else return an array of information for each notification sent (success, statusCode, headers, content)
-     *
-     * @throws \ErrorException
-     */
+	/**
+	 * Flush notifications. Triggers the requests.
+	 *
+	 * @param null|int $batchSize Defaults the value defined in defaultOptions during instantiation (which defaults to 1000).
+	 *
+	 * @return bool|MessageSentReport|\Generator
+	 * @throws \ErrorException
+	 */
     public function flush(?int $batchSize = null)
     {
         if (empty($this->notifications)) {
@@ -162,52 +159,31 @@ class WebPush
         }
 
         $batches = array_chunk($this->notifications, $batchSize);
-        $return = [];
-        $completeSuccess = true;
+
         foreach ($batches as $batch) {
-            // for each endpoint server type
-            $requests = $this->prepare($batch);
-            $promises = [];
-            foreach ($requests as $request) {
-                $promises[] = $this->client->sendAsync($request);
-            }
-            $results = Promise\settle($promises)->wait();
+	        // for each endpoint server type
+	        $requests = $this->prepare($batch);
 
-            foreach ($results as $result) {
-                if ($result['state'] === "rejected") {
-                    /** @var RequestException $reason **/
-                    $reason = $result['reason'];
+	        foreach ($requests as $request) {
+	        	$result = null;
 
-                    $error = [
-                        'success' => false,
-                        'endpoint' => $reason->getRequest()->getUri(),
-                        'message' => $reason->getMessage(),
-                    ];
+		        $this->client->sendAsync($request)
+			        ->then(function ($response) use ($request, &$result) {
+				        /** @var ResponseInterface $response * */
+				        $result = new MessageSentReport($request, $response);
+			        })
+			        ->otherwise(function ($reason) use (&$result) {
+				        /** @var RequestException $reason **/
+				        $result = new MessageSentReport($reason->getRequest(), $reason->getResponse(), false, $reason->getMessage());
+			        })
+			        ->wait(false);
 
-                    $response = $reason->getResponse();
-                    if ($response !== null) {
-                        $statusCode = $response->getStatusCode();
-                        $error['statusCode'] = $statusCode;
-                        $error['reasonPhrase'] = $response->getReasonPhrase();
-                        $error['expired'] = in_array($statusCode, [404, 410]);
-                        $error['content'] = $response->getBody();
-                        $error['headers'] = $response->getHeaders();
-                    }
-
-                    $return[] = $error;
-                    $completeSuccess = false;
-                } else {
-                    $return[] = [
-                        'success' => true,
-                    ];
-                }
-            }
+		        yield $result;
+	        }
         }
 
         // reset queue
         $this->notifications = null;
-
-        return $completeSuccess ? true : $return;
     }
 
     /**

--- a/tests/PushServiceTest.php
+++ b/tests/PushServiceTest.php
@@ -178,7 +178,12 @@ final class PushServiceTest extends PHPUnit\Framework\TestCase
 
                 try {
                     $sendResp = $this->webPush->sendNotification($subscription, $payload, true);
-                    $this->assertTrue($sendResp);
+                    $this->assertInstanceOf(\Generator::class, $sendResp);
+
+                    /** @var \Minishlink\WebPush\MessageSentReport $report */
+	                foreach ($sendResp as $report) {
+                    	$this->assertTrue($report->isSuccess());
+                    }
 
                     $dataString = json_encode([
                         'testSuiteId' => self::$testSuiteId,


### PR DESCRIPTION
As discussed in #183:

- [x] provide a mapped request/response report when sending a bunch of messages
- [x] utilize the `\Generator` object for better performance
- [x] add some documentation on running the tests for making contributions easier
- [x] update documentation on sending requests in bulk