### PR TITLE
Feature report enhance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,13 @@
       "homepage": "https://github.com/Minishlink"
     }
   ],
+  "scripts": {
+    "test": "./vendor/bin/phpunit --color"
+  },
   "require": {
     "php": "^7.1",
+    "ext-json": "*",
+    "ext-gmp": "*",
     "lib-openssl": "*",
     "guzzlehttp/guzzle": "^6.2",
     "web-token/jwt-signature": "^1.0",

--- a/src/MessageSentReport.php
+++ b/src/MessageSentReport.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * Standardized response from sending a message
  */
-class MessageSentReport {
+class MessageSentReport implements \JsonSerializable {
 
 	/**
 	 * @var boolean
@@ -127,5 +127,32 @@ class MessageSentReport {
 	public function setReason(string $reason): MessageSentReport {
 		$this->reason = $reason;
 		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getRequestPayload(): string {
+		return $this->request->getBody()->getContents();
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getResponseContent(): string {
+		return $this->response->getBody()->getContents();
+	}
+
+	/**
+	 * @return array|mixed
+	 */
+	public function jsonSerialize() {
+		return [
+			'success'  => $this->isSuccess(),
+			'expired'  => $this->isSubscriptionExpired(),
+			'reason'   => $this->reason,
+			'endpoint' => $this->getEndpoint(),
+			'payload'  => $this->request->getBody()->getContents(),
+		];
 	}
 }

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -19,7 +19,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\ResponseInterface;
 
-class WebPush implements \Countable
+class WebPush
 {
     public const GCM_URL = 'https://android.googleapis.com/gcm/send';
     public const FCM_BASE_URL = 'https://fcm.googleapis.com';
@@ -330,7 +330,7 @@ class WebPush implements \Countable
 	/**
 	 * @return int
 	 */
-	public function count(): int {
+	public function countPendingNotifications(): int {
 		return null !== $this->notifications ? count($this->notifications) : 0;
     }
 }

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -19,7 +19,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\ResponseInterface;
 
-class WebPush
+class WebPush implements \Countable
 {
     public const GCM_URL = 'https://android.googleapis.com/gcm/send';
     public const FCM_BASE_URL = 'https://fcm.googleapis.com';
@@ -134,7 +134,7 @@ class WebPush
 	 */
     public function flush(?int $batchSize = null) : iterable
     {
-        if (empty($this->notifications)) {
+        if (null === $this->notifications || empty($this->notifications)) {
 	        yield from [];
         }
 
@@ -325,5 +325,12 @@ class WebPush
         $this->defaultOptions['urgency'] = isset($defaultOptions['urgency']) ? $defaultOptions['urgency'] : null;
         $this->defaultOptions['topic'] = isset($defaultOptions['topic']) ? $defaultOptions['topic'] : null;
         $this->defaultOptions['batchSize'] = isset($defaultOptions['batchSize']) ? $defaultOptions['batchSize'] : 1000;
+    }
+
+	/**
+	 * @return int
+	 */
+	public function count(): int {
+		return null !== $this->notifications ? count($this->notifications) : 0;
     }
 }

--- a/tests/MessageSentReportTest.php
+++ b/tests/MessageSentReportTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * @author Igor Timoshenkov [it@campoint.net]
+ * @started: 2018-12-03 11:31
+ */
+
+use GuzzleHttp\Psr7\Request;
+use \Minishlink\WebPush\MessageSentReport;
+use \GuzzleHttp\Psr7\Response;
+
+/**
+ * @covers \Minishlink\WebPush\MessageSentReport
+ */
+class MessageSentReportTest extends \PHPUnit\Framework\TestCase {
+
+	/**
+	 * @param MessageSentReport $report
+	 * @param bool              $expected
+	 * @dataProvider generateReportsWithExpiration
+	 */
+	public function testIsSubscriptionExpired(MessageSentReport $report, bool $expected): void {
+		$this->assertEquals($expected, $report->isSubscriptionExpired());
+	}
+
+	/**
+	 * @return array
+	 */
+	public function generateReportsWithExpiration(): array {
+		return [
+			[new MessageSentReport(null, new Response(404)), true],
+			[new MessageSentReport(null, new Response(410)), true],
+			[new MessageSentReport(null, new Response(500)), false],
+			[new MessageSentReport(null, new Response(200)), false]
+		];
+	}
+
+	/**
+	 * @param MessageSentReport $report
+	 * @param string            $expected
+	 * @dataProvider generateReportsWithEndpoints
+	 */
+	public function testGetEndpoint(MessageSentReport $report, string $expected): void {
+		$this->assertEquals($expected, $report->getEndpoint());
+	}
+
+	/**
+	 * @return array
+	 */
+	public function generateReportsWithEndpoints(): array {
+		return [
+			[new MessageSentReport(new Request('POST', 'https://www.example.com')), 'https://www.example.com'],
+			[new MessageSentReport(new Request('POST', 'https://m.example.com')), 'https://m.example.com'],
+			[new MessageSentReport(new Request('POST', 'https://test.net')), 'https://test.net'],
+		];
+	}
+
+	/**
+	 * @param MessageSentReport $report
+	 * @param Request           $expected
+	 * @dataProvider generateReportsWithRequests
+	 */
+	public function testGetRequest(MessageSentReport $report, Request $expected): void {
+		$this->assertEquals($expected, $report->getRequest());
+	}
+
+	public function generateReportsWithRequests(): array {
+		$r1 = new Request('POST', 'https://www.example.com');
+		$r2 = new Request('PUT', 'https://m.example.com');
+		$r3 = new Request('GET', 'https://test.net');
+
+		return [
+			[new MessageSentReport($r1), $r1],
+			[new MessageSentReport($r2), $r2],
+			[new MessageSentReport($r3), $r3],
+		];
+	}
+
+	/**
+	 * @param MessageSentReport $report
+	 * @param string            $json
+	 * @dataProvider generateReportsWithJson
+	 */
+	public function testJsonSerialize(MessageSentReport $report, string $json): void {
+		$this->assertJsonStringEqualsJsonString($json, json_encode($report));
+	}
+
+	public function generateReportsWithJson(): array {
+		$request1Body = json_encode(['title' => 'test', 'body' => 'blah', 'data' => []]);
+		$request1 = new Request('POST', 'https://www.example.com', [], $request1Body);
+		$response1 = new Response(200, [], 'test');
+
+		$request2Body = '';
+		$request2 = new Request('POST', 'https://www.example.com', [], $request2Body);
+		$response2 = new Response(410, [], 'Faield to do somthing', '1.1', 'Gone');
+
+		return [
+			[
+				new MessageSentReport($request1, $response1),
+				json_encode([
+					'success'  => true,
+					'expired'  => false,
+					'reason'   => 'OK',
+					'endpoint' => (string) $request1->getUri(),
+					'payload'  => $request1Body,
+				])
+			],
+			[
+				new MessageSentReport($request2, $response2, false, 'Gone'),
+				json_encode([
+					'success'  => false,
+					'expired'  => true,
+					'reason'   => 'Gone',
+					'endpoint' => (string) $request2->getUri(),
+					'payload'  => $request2Body,
+				])
+			]
+		];
+	}
+
+	/**
+	 * @param MessageSentReport $report
+	 * @param bool              $expected
+	 * @dataProvider generateReportsWithSuccess
+	 */
+	public function testIsSuccess(MessageSentReport $report, bool $expected): void {
+		$this->assertEquals($expected, $report->isSuccess());
+	}
+
+	/**
+	 * @return array
+	 */
+	public function generateReportsWithSuccess(): array {
+		return [
+			[new MessageSentReport(), true],
+			[new MessageSentReport(null, null, true), true],
+			[new MessageSentReport(null, null, false), false],
+		];
+	}
+}

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -182,6 +182,24 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
 	    }
     }
 
+	public function testFlushEmpty(): void {
+		$this->webPush->flush(300);
+    }
+
+	/**
+	 * @throws ErrorException
+	 */
+	public function testCount(): void {
+		$subscription = new Subscription(self::$endpoints['standard']);
+
+		$this->webPush->sendNotification($subscription);
+		$this->webPush->sendNotification($subscription);
+		$this->webPush->sendNotification($subscription);
+		$this->webPush->sendNotification($subscription);
+
+		$this->assertCount(4, $this->webPush);
+    }
+
     /**
      * @throws ErrorException
      */


### PR DESCRIPTION
- Add a possibilty to get the count of the notifications in pipeline by implementing `\Countable`
- Add several helper methods to `MessageSentReport` class to ease integration
- Add tests for new helper methods
- Fix `flush()`-ing an empty notifications list (`null` passed to `array_chunk`)
- Add ext info to composer, add a short-cut for testing, e.g. `composer test`