### PR TITLE
Fixed Issue #194

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -64,20 +64,20 @@ class Subscription
      * @throws \ErrorException
      */
     public static function create(array $associativeArray): Subscription {
-        if (array_key_exists('publicKey', $associativeArray) || array_key_exists('authToken', $associativeArray) || array_key_exists('contentEncoding', $associativeArray)) {
-            return new self(
-                $associativeArray['endpoint'],
-                $associativeArray['publicKey'] ?? null,
-                $associativeArray['authToken'] ?? null,
-                $associativeArray['contentEncoding'] ?? "aesgcm"
-            );
-        }
-
         if (array_key_exists('keys', $associativeArray) && is_array($associativeArray['keys'])) {
             return new self(
                 $associativeArray['endpoint'],
                 $associativeArray['keys']['p256dh'] ?? null,
                 $associativeArray['keys']['auth'] ?? null,
+                $associativeArray['contentEncoding'] ?? "aesgcm"
+            );
+        }
+
+        if (array_key_exists('publicKey', $associativeArray) || array_key_exists('authToken', $associativeArray) || array_key_exists('contentEncoding', $associativeArray)) {
+            return new self(
+                $associativeArray['endpoint'],
+                $associativeArray['publicKey'] ?? null,
+                $associativeArray['authToken'] ?? null,
                 $associativeArray['contentEncoding'] ?? "aesgcm"
             );
         }


### PR DESCRIPTION
Changed the order of if statements.

The problem was caused because the user provided a content encoding type. 

Every time if a content encoding type was given the create method of class Subscription returned a new subscription based on the "auth-token" authorization format.

The issue creator used the variant where you provide the array 'keys' for authorization.
This format could not be used if you provided a content encoding type.
This is now fixed by changing the statement order.

#194 