### PR TITLE
Fix "Uncaught Error: Call to a member function getStatusCode() on null"

### DIFF
--- a/src/MessageSentReport.php
+++ b/src/MessageSentReport.php
@@ -109,6 +109,10 @@ class MessageSentReport {
 	 * @return bool
 	 */
 	public function isSubscriptionExpired(): bool {
+		if (!$this->response) {
+			return false;
+		}
+
 		return \in_array($this->response->getStatusCode(), [404, 410], true);
 	}
 


### PR DESCRIPTION
The method "MessageSentReport::getStatusCode" now considers that its "response" property can be null (because Guzzle can return null when calling "RequestException::getResponse").

I think this can happen if there is a network error.