### PR TITLE
Make lib more performant by allowing to provide local key objects and shared secrets

### DIFF
--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -266,24 +266,24 @@ class Encryption
     }
 
     /**
-     * @param string $encodedSerializedPublicKey
-     * @param        $encodedSerializedPrivateKey
+     * @param string $encodedPublicKey
+     * @param        $encodedPrivateKey
      *
      * @return array
      */
-    public static function createLocalKeyObjectUsingKeys(string $encodedSerializedPublicKey, string $encodedSerializedPrivateKey): array
+    public static function createLocalKeyObjectUsingKeys(string $encodedPublicKey, string $encodedPrivateKey): array
     {
-        $decodedSerializedPublicKey = Base64Url::decode($encodedSerializedPublicKey);
-        $decodedSerializedPrivateKey = Base64Url::decode($encodedSerializedPrivateKey);
+        $publicKey = Base64Url::decode($encodedPublicKey);
+        $privateKey = Base64Url::decode($encodedPrivateKey);
 
-        [$x, $y] = Utils::unserializePublicKey($decodedSerializedPublicKey);
+        [$x, $y] = Utils::unserializePublicKey($publicKey);
 
         return [
             NistCurve::curve256()->getPublicKeyFrom(
                 gmp_init(bin2hex($x), 16),
                 gmp_init(bin2hex($y), 16)
             ),
-            PrivateKey::create(gmp_init(bin2hex($decodedSerializedPrivateKey), 16))
+            PrivateKey::create(gmp_init(bin2hex($privateKey), 16))
         ];
     }
 

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -46,39 +46,48 @@ class Encryption
     }
 
     /**
-     * @param string $payload With padding
-     * @param string $userPublicKey Base 64 encoded (MIME or URL-safe)
-     * @param string $userAuthToken Base 64 encoded (MIME or URL-safe)
-     * @param string $contentEncoding
+     * @param string      $payload         With padding
+     * @param string      $userPublicKey   Base 64 encoded (MIME or URL-safe)
+     * @param string      $userAuthToken   Base 64 encoded (MIME or URL-safe)
+     * @param string      $contentEncoding
+     * @param string|null $sharedSecret
+     * @param string|null $localPublicKey  Base 64 encoded (MIME or URL-safe)
+     * @param string|null $localPrivateKey Base 64 encoded (MIME or URL-safe)
+     *
      * @return array
      *
      * @throws \ErrorException
      */
-    public static function encrypt(string $payload, string $userPublicKey, string $userAuthToken, string $contentEncoding): array
+    public static function encrypt(string $payload, string $userPublicKey, string $userAuthToken, string $contentEncoding = null, string $sharedSecret = null, string $localPublicKey = null, string $localPrivateKey = null): array
     {
         return self::deterministicEncrypt(
             $payload,
             $userPublicKey,
             $userAuthToken,
             $contentEncoding,
-            self::createLocalKeyObject(),
-            random_bytes(16)
+            self::createLocalKeyObject($localPublicKey, $localPrivateKey),
+            random_bytes(16),
+            $sharedSecret
         );
     }
 
     /**
-     * @param string $payload
-     * @param string $userPublicKey
-     * @param string $userAuthToken
-     * @param string $contentEncoding
-     * @param array $localKeyObject
-     * @param string $salt
+     * @param string      $payload
+     * @param string      $userPublicKey
+     * @param string      $userAuthToken
+     * @param string      $contentEncoding
+     * @param array       $localKeyObject
+     * @param string      $salt
+     * @param string|null $sharedSecret
+     *
      * @return array
      *
      * @throws \ErrorException
      */
-    public static function deterministicEncrypt(string $payload, string $userPublicKey, string $userAuthToken, string $contentEncoding, array $localKeyObject, string $salt): array
+    public static function deterministicEncrypt(string $payload, string $userPublicKey, string $userAuthToken, string $contentEncoding, array $localKeyObject, string $salt, string $sharedSecret = null): array
     {
+        \App\Profiler::getInstance()->startTimer('deterministicEncrypt (total)');
+
         $userPublicKey = Base64Url::decode($userPublicKey);
         $userAuthToken = Base64Url::decode($userAuthToken);
 
@@ -95,9 +104,14 @@ class Encryption
             gmp_init(bin2hex($userPublicKeyObjectY), 16)
         );
 
-        // get shared secret from user public key and local private key
-        $sharedSecret = $curve->mul($userPublicKeyObject->getPoint(), $localPrivateKeyObject->getSecret())->getX();
-        $sharedSecret = hex2bin(str_pad(gmp_strval($sharedSecret, 16), 64, '0', STR_PAD_LEFT));
+        \App\Profiler::getInstance()->startTimer('deterministicEncrypt (Busy part)');
+        if (!$sharedSecret) {
+            // get shared secret from user public key and local private key
+            $sharedSecret = $curve->mul($userPublicKeyObject->getPoint(), $localPrivateKeyObject->getSecret())->getX();
+            $sharedSecret = str_pad(gmp_strval($sharedSecret, 16), 64, '0', STR_PAD_LEFT);
+        }
+        $sharedSecret = hex2bin($sharedSecret);
+        \App\Profiler::getInstance()->stopTimer('deterministicEncrypt (Busy part)');
 
         // section 4.3
         $ikm = self::getIKM($userAuthToken, $userPublicKey, $localPublicKey, $sharedSecret, $contentEncoding);
@@ -116,6 +130,8 @@ class Encryption
         // encrypt
         // "The additional data passed to each invocation of AEAD_AES_128_GCM is a zero-length octet sequence."
         $encryptedText = openssl_encrypt($payload, 'aes-128-gcm', $contentEncryptionKey, OPENSSL_RAW_DATA, $nonce, $tag);
+
+        \App\Profiler::getInstance()->stopTimer('deterministicEncrypt (total)');
 
         // return values in url safe base64
         return [
@@ -231,10 +247,40 @@ class Encryption
     }
 
     /**
+     * @param string $encodedSerializedPublicKey
+     * @param        $encodedSerializedPrivateKey
+     *
      * @return array
      */
-    private static function createLocalKeyObject(): array
+    public static function createLocalKeyObjectUsingProvidedKeys(string $encodedSerializedPublicKey, $encodedSerializedPrivateKey): array
     {
+        $decodedSerializedPublicKey = Base64Url::decode($encodedSerializedPublicKey);
+        $decodedSerializedPrivateKey = Base64Url::decode($encodedSerializedPrivateKey);
+
+        [$x, $y] = Utils::unserializePublicKey(hex2bin($decodedSerializedPublicKey));
+        $secret = Utils::unserializePrivateKey($decodedSerializedPrivateKey);
+
+        return [
+            NistCurve::curve256()->getPublicKeyFrom(
+                gmp_init(bin2hex($x), 16),
+                gmp_init(bin2hex($y), 16)
+            ),
+            PrivateKey::create($secret)
+        ];
+    }
+
+    /**
+     * @param string|null $localPublicKey
+     * @param string|null $localPrivateKey
+     *
+     * @return array
+     */
+    public static function createLocalKeyObject(string $localPublicKey = null, string $localPrivateKey = null): array
+    {
+        if ($localPublicKey&& $localPrivateKey) {
+            return self::createLocalKeyObjectUsingProvidedKeys($localPublicKey, $localPrivateKey);
+        }
+
         try {
             return self::createLocalKeyObjectUsingOpenSSL();
         } catch (\Exception $e) {

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -254,7 +254,7 @@ class Encryption
      *
      * @return array
      */
-    public static function createLocalKeyObjectUsingProvidedKeys(string $encodedSerializedPublicKey, $encodedSerializedPrivateKey): array
+    private static function createLocalKeyObjectUsingProvidedKeys(string $encodedSerializedPublicKey, $encodedSerializedPrivateKey): array
     {
         $decodedSerializedPublicKey = Base64Url::decode($encodedSerializedPublicKey);
         $decodedSerializedPrivateKey = Base64Url::decode($encodedSerializedPrivateKey);

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -104,10 +104,10 @@ class Encryption
         } else {
             // Decode the provided shared secret
             $sharedSecret = Base64Url::decode($sharedSecret);
-        }
 
-        if (!$sharedSecret) {
-            throw new \ErrorException('Failed to convert shared secret from hexadecimal to binary');
+            if (!$sharedSecret) {
+                throw new \ErrorException('Failed to decode the given sharedsecret');
+            }
         }
 
         // section 4.3
@@ -144,8 +144,9 @@ class Encryption
      * @param PrivateKey $localPrivateKey
      *
      * @return string
+     * @throws \ErrorException
      */
-    public static function createSharedSecret(string $userPublicKey, PrivateKey $localPrivateKey)
+    public static function createSharedSecret(string $userPublicKey, PrivateKey $localPrivateKey): string
     {
         $curve = NistCurve::curve256();
 
@@ -159,7 +160,13 @@ class Encryption
 
         $sharedSecret = $curve->mul($userPublicKeyObject->getPoint(), $localPrivateKey->getSecret())->getX();
 
-        return hex2bin(str_pad(gmp_strval($sharedSecret, 16), 64, '0', STR_PAD_LEFT));
+        $sharedSecret = hex2bin(str_pad(gmp_strval($sharedSecret, 16), 64, '0', STR_PAD_LEFT));
+
+        if (!$sharedSecret) {
+            throw new \ErrorException('Failed to convert shared secret from hexadecimal to binary');
+        }
+
+        return $sharedSecret;
     }
 
     public static function getContentCodingHeader($salt, $localPublicKey, $contentEncoding): string

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -58,7 +58,7 @@ class Encryption
      *
      * @throws \ErrorException
      */
-    public static function encrypt(string $payload, string $userPublicKey, string $userAuthToken, string $contentEncoding = null, ?array $localKeyObject = null, string $sharedSecret = null): array
+    public static function encrypt(string $payload, string $userPublicKey, string $userAuthToken, string $contentEncoding, ?array $localKeyObject = null, ?string $sharedSecret = null): array
     {
         return self::deterministicEncrypt(
             $payload,
@@ -84,7 +84,7 @@ class Encryption
      *
      * @throws \ErrorException
      */
-    public static function deterministicEncrypt(string $payload, string $userPublicKey, string $userAuthToken, string $contentEncoding, array $localKeyObject, string $salt, string $sharedSecret = null): array
+    public static function deterministicEncrypt(string $payload, string $userPublicKey, string $userAuthToken, string $contentEncoding, array $localKeyObject, string $salt, ?string $sharedSecret = null): array
     {
         $userPublicKey = Base64Url::decode($userPublicKey);
         $userAuthToken = Base64Url::decode($userAuthToken);
@@ -143,7 +143,7 @@ class Encryption
      * @param string $userPublicKey
      * @param PrivateKey $localPrivateKey
      *
-     * @return bool|string
+     * @return string
      */
     public static function createSharedSecret(string $userPublicKey, PrivateKey $localPrivateKey)
     {
@@ -260,7 +260,7 @@ class Encryption
             }
 
             return 'Content-Encoding: '.$type.chr(0).'P-256'.$context;
-        } else if ($contentEncoding === "aes128gcm") {
+        } elseif ($contentEncoding === "aes128gcm") {
             return 'Content-Encoding: '.$type.chr(0);
         }
 
@@ -269,7 +269,7 @@ class Encryption
 
     /**
      * @param string $encodedPublicKey
-     * @param        $encodedPrivateKey
+     * @param string $encodedPrivateKey
      *
      * @return array
      */

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -27,6 +27,9 @@ class Subscription
     /** @var null|string */
     private $contentEncoding;
 
+    /** @var null|string */
+    private $sharedSecret;
+
     /**
      * Subscription constructor.
      *
@@ -40,7 +43,8 @@ class Subscription
         string $endpoint,
         ?string $publicKey = null,
         ?string $authToken = null,
-        ?string $contentEncoding = null
+        ?string $contentEncoding = null,
+        ?string $sharedSecret = null
     ) {
         $this->endpoint = $endpoint;
 
@@ -53,6 +57,7 @@ class Subscription
             $this->publicKey = $publicKey;
             $this->authToken = $authToken;
             $this->contentEncoding = $contentEncoding ?: "aesgcm";
+            $this->sharedSecret = $sharedSecret;
         }
     }
 
@@ -64,12 +69,13 @@ class Subscription
      * @throws \ErrorException
      */
     public static function create(array $associativeArray): Subscription {
-        if (array_key_exists('publicKey', $associativeArray) || array_key_exists('authToken', $associativeArray) || array_key_exists('contentEncoding', $associativeArray)) {
+        if (array_key_exists('publicKey', $associativeArray) || array_key_exists('authToken', $associativeArray) || array_key_exists('contentEncoding', $associativeArray) || array_key_exists('sharedSecret', $associativeArray)) {
             return new self(
                 $associativeArray['endpoint'],
                 $associativeArray['publicKey'] ?? null,
                 $associativeArray['authToken'] ?? null,
-                $associativeArray['contentEncoding'] ?? "aesgcm"
+                $associativeArray['contentEncoding'] ?? "aesgcm",
+                $associativeArray['sharedSecret']
             );
         }
 
@@ -117,5 +123,13 @@ class Subscription
     public function getContentEncoding(): ?string
     {
         return $this->contentEncoding;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSharedSecret(): ?string
+    {
+        return $this->sharedSecret;
     }
 }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -37,6 +37,7 @@ class Subscription
      * @param null|string $publicKey
      * @param null|string $authToken
      * @param string $contentEncoding (Optional) Must be "aesgcm"
+     * @param null|string $sharedSecret
      * @throws \ErrorException
      */
     public function __construct(
@@ -57,7 +58,10 @@ class Subscription
             $this->publicKey = $publicKey;
             $this->authToken = $authToken;
             $this->contentEncoding = $contentEncoding ?: "aesgcm";
-            $this->sharedSecret = $sharedSecret;
+
+            if($sharedSecret) {
+                $this->sharedSecret = $sharedSecret;
+            }
         }
     }
 
@@ -75,7 +79,8 @@ class Subscription
                 $associativeArray['endpoint'],
                 $associativeArray['keys']['p256dh'] ?? null,
                 $associativeArray['keys']['auth'] ?? null,
-                $associativeArray['contentEncoding'] ?? "aesgcm"
+                $associativeArray['contentEncoding'] ?? "aesgcm",
+                $associativeArray['sharedSecret'] ?? null
             );
         }
 
@@ -85,7 +90,7 @@ class Subscription
                 $associativeArray['publicKey'] ?? null,
                 $associativeArray['authToken'] ?? null,
                 $associativeArray['contentEncoding'] ?? "aesgcm",
-                $associativeArray['sharedSecret']
+                $associativeArray['sharedSecret'] ?? null
             );
         }
 
@@ -127,7 +132,7 @@ class Subscription
     }
 
     /**
-     * @return string|null
+     * @return null|string
      */
     public function getSharedSecret(): ?string
     {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -59,7 +59,7 @@ class Subscription
             $this->authToken = $authToken;
             $this->contentEncoding = $contentEncoding ?: "aesgcm";
 
-            if($sharedSecret) {
+            if ($sharedSecret) {
                 $this->sharedSecret = $sharedSecret;
             }
         }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Minishlink\WebPush;
 
+use Jose\Component\Core\Util\Ecc\PrivateKey;
 use Jose\Component\Core\Util\Ecc\PublicKey;
 
 class Utils
@@ -42,6 +43,16 @@ class Utils
     }
 
     /**
+     * @param PublicKey $publicKey
+     *
+     * @return string
+     */
+    public static function serializePrivateKey(PrivateKey $privateKey): string
+    {
+        return serialize($privateKey->getSecret());
+    }
+
+    /**
      * @param string $data
      *
      * @return array
@@ -60,5 +71,14 @@ class Utils
             hex2bin(mb_substr($data, 0, $dataLength / 2, '8bit')),
             hex2bin(mb_substr($data, $dataLength / 2, null, '8bit')),
         ];
+    }
+    /**
+     * @param string $data
+     *
+     * @return array
+     */
+    public static function unserializePrivateKey(string $data): \GMP
+    {
+        return unserialize($data);
     }
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -66,9 +66,9 @@ class Utils
     /**
      * @param PrivateKey $privateKey
      *
-     * @return string
+     * @return bool|string
      */
-    public static function serializePrivateKey(PrivateKey $privateKey): string
+    public static function serializePrivateKey(PrivateKey $privateKey)
     {
         return hex2bin(gmp_strval($privateKey->getSecret(), 16));
     }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Minishlink\WebPush;
 
+use Jose\Component\Core\Util\Ecc\PrivateKey;
 use Jose\Component\Core\Util\Ecc\PublicKey;
 
 class Utils
@@ -59,5 +60,26 @@ class Utils
             hex2bin(mb_substr($data, 0, $dataLength / 2, '8bit')),
             hex2bin(mb_substr($data, $dataLength / 2, null, '8bit')),
         ];
+    }
+
+
+    /**
+     * @param PrivateKey $privateKey
+     *
+     * @return string
+     */
+    public static function serializePrivateKey(PrivateKey $privateKey): string
+    {
+        return hex2bin(gmp_strval($privateKey->getSecret(), 16));
+    }
+
+    /**
+     * @param string $data
+     *
+     * @return PrivateKey
+     */
+    public static function unserializePrivateKey(string $data): PrivateKey
+    {
+        return PrivateKey::create(gmp_init(bin2hex($data), 16));
     }
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Minishlink\WebPush;
 
-use Jose\Component\Core\Util\Ecc\PrivateKey;
 use Jose\Component\Core\Util\Ecc\PublicKey;
 
 class Utils
@@ -43,16 +42,6 @@ class Utils
     }
 
     /**
-     * @param PublicKey $publicKey
-     *
-     * @return string
-     */
-    public static function serializePrivateKey(PrivateKey $privateKey): string
-    {
-        return serialize($privateKey->getSecret());
-    }
-
-    /**
      * @param string $data
      *
      * @return array
@@ -70,14 +59,5 @@ class Utils
             hex2bin(mb_substr($data, 0, $dataLength / 2, '8bit')),
             hex2bin(mb_substr($data, $dataLength / 2, null, '8bit')),
         ];
-    }
-    /**
-     * @param string $data
-     *
-     * @return array
-     */
-    public static function unserializePrivateKey(string $data): \GMP
-    {
-        return unserialize($data);
     }
 }

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -152,7 +152,6 @@ class WebPush
 	        // for each endpoint server type
 	        $requests = $this->prepare($batch);
 
-	        /** @var Promise[] $promises */
             $promises = [];
 
 	        foreach ($requests as $request) {
@@ -161,7 +160,7 @@ class WebPush
 				        /** @var ResponseInterface $response * */
 				        return new MessageSentReport($request, $response);
 			        })
-			        ->otherwise(function ($reason) use (&$result) {
+			        ->otherwise(function ($reason) {
 				        /** @var RequestException $reason **/
 				        return new MessageSentReport($reason->getRequest(), $reason->getResponse(), false, $reason->getMessage());
 			        });

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -16,6 +16,7 @@ namespace Minishlink\WebPush;
 use Base64Url\Base64Url;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\ResponseInterface;
 
@@ -151,22 +152,24 @@ class WebPush
 	        // for each endpoint server type
 	        $requests = $this->prepare($batch);
 
-	        foreach ($requests as $request) {
-	        	$result = null;
+	        /** @var Promise[] $promises */
+            $promises = [];
 
-		        $this->client->sendAsync($request)
-			        ->then(function ($response) use ($request, &$result) {
+	        foreach ($requests as $request) {
+                $promises[] = $this->client->sendAsync($request)
+			        ->then(function ($response) use ($request) {
 				        /** @var ResponseInterface $response * */
-				        $result = new MessageSentReport($request, $response);
+				        return new MessageSentReport($request, $response);
 			        })
 			        ->otherwise(function ($reason) use (&$result) {
 				        /** @var RequestException $reason **/
-				        $result = new MessageSentReport($reason->getRequest(), $reason->getResponse(), false, $reason->getMessage());
-			        })
-			        ->wait(false);
-
-		        yield $result;
+				        return new MessageSentReport($reason->getRequest(), $reason->getResponse(), false, $reason->getMessage());
+			        });
 	        }
+
+	        foreach ($promises as $promise) {
+	            yield $promise->wait();
+            }
         }
     }
 

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -177,7 +177,7 @@ class WebPush
             // for each endpoint server type
             $requests = $this->prepare($batch);
 
-	        /** @var \GuzzleHttp\Promise\Promise[] $promises */
+            /** @var \GuzzleHttp\Promise\Promise[] $promises */
             $promises = [];
 
             foreach ($requests as $request) {
@@ -231,7 +231,7 @@ class WebPush
 
                 $localKeyObject = null;
 
-                if($this->localPublicKey && $this->localPrivateKey) {
+                if ($this->localPublicKey && $this->localPrivateKey) {
                     $localKeyObject = Encryption::createLocalKeyObjectUsingKeys($this->localPublicKey, $this->localPrivateKey);
                 }
 

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -229,7 +229,11 @@ class WebPush
                     throw new \ErrorException('Subscription should have a content encoding');
                 }
 
-                $localKeyObject = Encryption::createLocalKeyObjectUsingKeys($this->localPublicKey, $this->localPrivateKey);
+                $localKeyObject = null;
+
+                if($this->localPublicKey && $this->localPrivateKey) {
+                    $localKeyObject = Encryption::createLocalKeyObjectUsingKeys($this->localPublicKey, $this->localPrivateKey);
+                }
 
                 $encrypted = Encryption::encrypt($payload, $userPublicKey, $userAuthToken, $contentEncoding, $localKeyObject, $sharedSecret);
                 $cipherText = $encrypted['cipherText'];

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -19,6 +19,9 @@ use Minishlink\WebPush\Utils;
 
 final class EncryptionTest extends PHPUnit\Framework\TestCase
 {
+    protected $localPublicKey = 'BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8';
+    protected $localPrivateKey = 'yfWPiYE-n46HLnH0KqZOF1fJJU3MYrct3AELtAQ-oRw';
+
     public function testDeterministicEncrypt()
     {
         $contentEncoding = "aes128gcm";
@@ -31,8 +34,8 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
         $userPublicKey = 'BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4';
         $userAuthToken = 'BTBZMqHH6r4Tts7J_aSIgg';
 
-        $localPublicKey = Base64Url::decode('BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8');
-        $localPrivateKey = Base64Url::decode('yfWPiYE-n46HLnH0KqZOF1fJJU3MYrct3AELtAQ-oRw');
+        $localPublicKey = Base64Url::decode($this->localPublicKey);
+        $localPrivateKey = Base64Url::decode($this->localPrivateKey);
         $salt = Base64Url::decode('DGv6ra1nlYgDCS1FRnbzlw');
 
         $localPrivateKeyObject = PrivateKey::create(gmp_init(bin2hex($localPrivateKey), 16));
@@ -42,6 +45,10 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
             gmp_init(bin2hex($localPublicKeyObjectX), 16),
             gmp_init(bin2hex($localPublicKeyObjectY), 16)
         );
+
+        $localKeyObject = Encryption::createLocalKeyObjectUsingKeys($this->localPublicKey, $this->localPrivateKey);
+
+        $this->assertEquals([$localPublicKeyObject, $localPrivateKeyObject], $localKeyObject);
 
         $expected = [
             'localPublicKey' => $localPublicKey,
@@ -65,7 +72,7 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
 
     public function testGetContentCodingHeader()
     {
-        $localPublicKey = Base64Url::decode('BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8');
+        $localPublicKey = Base64Url::decode($this->localPublicKey);
         $salt = Base64Url::decode('DGv6ra1nlYgDCS1FRnbzlw');
 
         $result = Encryption::getContentCodingHeader($salt, $localPublicKey, "aes128gcm");

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -38,7 +38,7 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
         $localPrivateKey = Base64Url::decode($this->localPrivateKey);
         $salt = Base64Url::decode('DGv6ra1nlYgDCS1FRnbzlw');
 
-        $localPrivateKeyObject = PrivateKey::create(gmp_init(bin2hex($localPrivateKey), 16));
+        $localPrivateKeyObject = Utils::unserializePrivateKey($localPrivateKey);
         $curve = NistCurve::curve256();
         [$localPublicKeyObjectX, $localPublicKeyObjectY] = Utils::unserializePublicKey($localPublicKey);
         $localPublicKeyObject = $curve->getPublicKeyFrom(

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -15,6 +15,7 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(null, $subscription->getPublicKey());
         $this->assertEquals(null, $subscription->getAuthToken());
         $this->assertEquals(null, $subscription->getContentEncoding());
+        $this->assertEquals(null, $subscription->getSharedSecret());
     }
 
     public function testConstructMinimal()
@@ -24,6 +25,7 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(null, $subscription->getPublicKey());
         $this->assertEquals(null, $subscription->getAuthToken());
         $this->assertEquals(null, $subscription->getContentEncoding());
+        $this->assertEquals(null, $subscription->getSharedSecret());
     }
 
     public function testCreatePartial()
@@ -56,21 +58,24 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
             "publicKey" => "publicKey",
             "authToken" => "authToken",
             "contentEncoding" => "aes128gcm",
+            "sharedSecret" => "sharedSecret",
         );
         $subscription = Subscription::create($subscriptionArray);
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
         $this->assertEquals("aes128gcm", $subscription->getContentEncoding());
+        $this->assertEquals("sharedSecret", $subscription->getSharedSecret());
     }
 
     public function testConstructFull()
     {
-        $subscription = new Subscription("http://toto.com", "publicKey", "authToken", "aes128gcm");
+        $subscription = new Subscription("http://toto.com", "publicKey", "authToken", "aes128gcm", "sharedSecret");
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
         $this->assertEquals("aes128gcm", $subscription->getContentEncoding());
+        $this->assertEquals("sharedSecret", $subscription->getSharedSecret());
     }
 
     public function testCreatePartialWithNewStructure()
@@ -101,5 +106,21 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
         $this->assertEquals("aes128gcm", $subscription->getContentEncoding());
+    }
+
+    public function testCreatePartialWithNewStructureAndSharedSecret()
+    {
+        $subscription = Subscription::create([
+            "endpoint" => "http://toto.com",
+            "sharedSecret" => 'sharedSecret',
+            "keys" => [
+                'p256dh' => 'publicKey',
+                'auth' => 'authToken'
+            ]
+        ]);
+        $this->assertEquals("http://toto.com", $subscription->getEndpoint());
+        $this->assertEquals("publicKey", $subscription->getPublicKey());
+        $this->assertEquals("authToken", $subscription->getAuthToken());
+        $this->assertEquals("sharedSecret", $subscription->getSharedSecret());
     }
 }

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -19,6 +19,7 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
     private static $endpoints;
     private static $keys;
     private static $tokens;
+    private static $secret;
 
     /** @var WebPush WebPush with correct api keys */
     private $webPush;
@@ -39,6 +40,10 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
         self::$tokens = [
             'standard' => getenv('USER_AUTH_TOKEN'),
         ];
+
+        self::$secret = [
+            'standard' => getenv('USER_SHARED_SECRET'),
+        ];
     }
 
     /**
@@ -52,6 +57,8 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
             'USER_AUTH_TOKEN',
             'VAPID_PUBLIC_KEY',
             'VAPID_PRIVATE_KEY',
+            'LOCAL_PUBLIC_KEY',
+            'LOCAL_PRIVATE_KEY',
         ];
         foreach ($envs as $env) {
             if (!getenv($env)) {
@@ -67,6 +74,7 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
             ],
         ]);
         $this->webPush->setAutomaticPadding(false); // disable automatic padding in tests to speed these up
+        $this->webPush->setLocalKeys(getenv('LOCAL_PUBLIC_KEY'),getenv('LOCAL_PRIVATE_KEY'));
     }
 
     /**
@@ -81,7 +89,7 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
         if (getenv('CI')) return [];
 
         return [
-            [new Subscription(self::$endpoints['standard'], self::$keys['standard'], self::$tokens['standard']), '{"message":"Comment ça va ?","tag":"general"}'],
+            [new Subscription(self::$endpoints['standard'], self::$keys['standard'], self::$tokens['standard'], null, self::$secret['standard']), '{"message":"Comment ça va ?","tag":"general"}'],
         ];
     }
 

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -59,6 +59,7 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
             'VAPID_PRIVATE_KEY',
             'LOCAL_PUBLIC_KEY',
             'LOCAL_PRIVATE_KEY',
+            'USER_SHARED_SECRET',
         ];
         foreach ($envs as $env) {
             if (!getenv($env)) {


### PR DESCRIPTION
This pull request adds the ability to generate the local keys before hand and provide them to the WebPush client. This way it does not generate a new local key object for each notification.

This also opens the possibility to generate the shared secret before hand so that this is also skipped when you send the notification.

Here is an example:

**Generate the local public and private key and store them**
```php
use Jose\Component\Core\Util\Ecc\NistCurve;
use Minishlink\WebPush\Encryption;
use Minishlink\WebPush\Utils;
use Base64Url\Base64Url;

[$localPublicKeyObject, $localPrivateKeyObject] = Encryption::createLocalKeyObject();

// Store these variables
$localPublicKey = Base64Url::encode(Utils::serializePublicKey($localPublicKeyObject));
$localPrivateKey = Base64Url::encode(Utils::serializePrivateKey($localPrivateKeyObject));
```
**When a user subscribes we generate the shared secret and store it with all the other info**
```php
use Minishlink\WebPush\Encryption;
use Minishlink\WebPush\Utils;
use Base64Url\Base64Url;

$localPrivateKey = Base64Url::decode('storedLocalPrivateKey');
$userPublicKey = "TheUsersPublicKey";

// Store the shared secret with the subscription
$sharedSecret = Encryption::createSharedSecret($userPublicKey, Utils::unserializePrivateKey($localPrivateKey));
```

**When you want to send a notification**
```php
use Minishlink\WebPush\Encryption;
use Minishlink\WebPush\Utils;
use Base64Url\Base64Url;

$localPublicKey = 'storedLocalPublicKey';
$localPrivateKey = 'storedLocalPrivateKey';

$webPush = new WebPush();
$webPush->setLocalKeys($localPublicKey, $localPrivateKey);

$endpoint = 'endpoint'; // From your data store
$publicKey = 'publicKey'; // From your data store
$authToken = 'authToken'; // From your data store
$contentEncoding= 'contentEncoding'; // From your data store
$sharedSecret = 'sharedSecret'; // From your data store, previously created

$subscriptions = new Subscription($endpoint, $publicKey, $authToken, $contentEncoding, $sharedSecret);

$webPush->sendNotification($subscription, '{"test":"payload"}');