### PR TITLE
Migrating from GCM to FCM by updating endpoint URL

### DIFF
--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -254,8 +254,8 @@ class WebPush
                 $headers['Topic'] = $options['topic'];
             }
 
-            // if GCM
-            if (substr($endpoint, 0, strlen(self::GCM_URL)) === self::GCM_URL) {
+            // if GCM or FCM using legacy GCM server key
+            if (array_key_exists('GCM', $auth) || substr($endpoint, 0, strlen(self::GCM_URL)) === self::GCM_URL) {
                 if (array_key_exists('GCM', $auth)) {
                     $headers['Authorization'] = 'key='.$auth['GCM'];
                 } else {


### PR DESCRIPTION
We need to switch to FCM fast, but need to keep old subscriptions working. So we cannot enable VAPID to solve this problem. FCM supports old legacy server key, so we can switch to FCM by updating endpoint url only.

Fixes https://github.com/web-push-libs/web-push-php/issues/223

An alternative (and maybe better way) is to change the endpoint URL, so developers will not need to change the gateway URL.