### PR TITLE
Make lib more performant by allowing to provide local key objects and…

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -27,6 +27,9 @@ class Subscription
     /** @var null|string */
     private $contentEncoding;
 
+    /** @var null|string */
+    private $sharedSecret;
+
     /**
      * Subscription constructor.
      *
@@ -34,13 +37,15 @@ class Subscription
      * @param null|string $publicKey
      * @param null|string $authToken
      * @param string $contentEncoding (Optional) Must be "aesgcm"
+     * @param null|string $sharedSecret
      * @throws \ErrorException
      */
     public function __construct(
         string $endpoint,
         ?string $publicKey = null,
         ?string $authToken = null,
-        ?string $contentEncoding = null
+        ?string $contentEncoding = null,
+        ?string $sharedSecret = null
     ) {
         $this->endpoint = $endpoint;
 
@@ -53,6 +58,10 @@ class Subscription
             $this->publicKey = $publicKey;
             $this->authToken = $authToken;
             $this->contentEncoding = $contentEncoding ?: "aesgcm";
+
+            if ($sharedSecret) {
+                $this->sharedSecret = $sharedSecret;
+            }
         }
     }
 
@@ -70,7 +79,8 @@ class Subscription
                 $associativeArray['endpoint'],
                 $associativeArray['keys']['p256dh'] ?? null,
                 $associativeArray['keys']['auth'] ?? null,
-                $associativeArray['contentEncoding'] ?? "aesgcm"
+                $associativeArray['contentEncoding'] ?? "aesgcm",
+                $associativeArray['sharedSecret'] ?? null
             );
         }
 
@@ -79,7 +89,8 @@ class Subscription
                 $associativeArray['endpoint'],
                 $associativeArray['publicKey'] ?? null,
                 $associativeArray['authToken'] ?? null,
-                $associativeArray['contentEncoding'] ?? "aesgcm"
+                $associativeArray['contentEncoding'] ?? "aesgcm",
+                $associativeArray['sharedSecret'] ?? null
             );
         }
 
@@ -118,5 +129,13 @@ class Subscription
     public function getContentEncoding(): ?string
     {
         return $this->contentEncoding;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getSharedSecret(): ?string
+    {
+        return $this->sharedSecret;
     }
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Minishlink\WebPush;
 
+use Jose\Component\Core\Util\Ecc\PrivateKey;
 use Jose\Component\Core\Util\Ecc\PublicKey;
 
 class Utils
@@ -59,5 +60,26 @@ class Utils
             hex2bin(mb_substr($data, 0, $dataLength / 2, '8bit')),
             hex2bin(mb_substr($data, $dataLength / 2, null, '8bit')),
         ];
+    }
+
+
+    /**
+     * @param PrivateKey $privateKey
+     *
+     * @return bool|string
+     */
+    public static function serializePrivateKey(PrivateKey $privateKey)
+    {
+        return hex2bin(gmp_strval($privateKey->getSecret(), 16));
+    }
+
+    /**
+     * @param string $data
+     *
+     * @return PrivateKey
+     */
+    public static function unserializePrivateKey(string $data): PrivateKey
+    {
+        return PrivateKey::create(gmp_init(bin2hex($data), 16));
     }
 }

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -19,6 +19,9 @@ use Minishlink\WebPush\Utils;
 
 final class EncryptionTest extends PHPUnit\Framework\TestCase
 {
+    protected $localPublicKey = 'BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8';
+    protected $localPrivateKey = 'yfWPiYE-n46HLnH0KqZOF1fJJU3MYrct3AELtAQ-oRw';
+
     public function testDeterministicEncrypt()
     {
         $contentEncoding = "aes128gcm";
@@ -31,17 +34,21 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
         $userPublicKey = 'BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4';
         $userAuthToken = 'BTBZMqHH6r4Tts7J_aSIgg';
 
-        $localPublicKey = Base64Url::decode('BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8');
-        $localPrivateKey = Base64Url::decode('yfWPiYE-n46HLnH0KqZOF1fJJU3MYrct3AELtAQ-oRw');
+        $localPublicKey = Base64Url::decode($this->localPublicKey);
+        $localPrivateKey = Base64Url::decode($this->localPrivateKey);
         $salt = Base64Url::decode('DGv6ra1nlYgDCS1FRnbzlw');
 
-        $localPrivateKeyObject = PrivateKey::create(gmp_init(bin2hex($localPrivateKey), 16));
+        $localPrivateKeyObject = Utils::unserializePrivateKey($localPrivateKey);
         $curve = NistCurve::curve256();
         [$localPublicKeyObjectX, $localPublicKeyObjectY] = Utils::unserializePublicKey($localPublicKey);
         $localPublicKeyObject = $curve->getPublicKeyFrom(
             gmp_init(bin2hex($localPublicKeyObjectX), 16),
             gmp_init(bin2hex($localPublicKeyObjectY), 16)
         );
+
+        $localKeyObject = Encryption::createLocalKeyObjectUsingKeys($this->localPublicKey, $this->localPrivateKey);
+
+        $this->assertEquals([$localPublicKeyObject, $localPrivateKeyObject], $localKeyObject);
 
         $expected = [
             'localPublicKey' => $localPublicKey,
@@ -65,7 +72,7 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
 
     public function testGetContentCodingHeader()
     {
-        $localPublicKey = Base64Url::decode('BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8');
+        $localPublicKey = Base64Url::decode($this->localPublicKey);
         $salt = Base64Url::decode('DGv6ra1nlYgDCS1FRnbzlw');
 
         $result = Encryption::getContentCodingHeader($salt, $localPublicKey, "aes128gcm");

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -15,6 +15,7 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(null, $subscription->getPublicKey());
         $this->assertEquals(null, $subscription->getAuthToken());
         $this->assertEquals(null, $subscription->getContentEncoding());
+        $this->assertEquals(null, $subscription->getSharedSecret());
     }
 
     public function testConstructMinimal()
@@ -24,6 +25,7 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(null, $subscription->getPublicKey());
         $this->assertEquals(null, $subscription->getAuthToken());
         $this->assertEquals(null, $subscription->getContentEncoding());
+        $this->assertEquals(null, $subscription->getSharedSecret());
     }
 
     public function testCreatePartial()
@@ -56,21 +58,24 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
             "publicKey" => "publicKey",
             "authToken" => "authToken",
             "contentEncoding" => "aes128gcm",
+            "sharedSecret" => "sharedSecret",
         );
         $subscription = Subscription::create($subscriptionArray);
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
         $this->assertEquals("aes128gcm", $subscription->getContentEncoding());
+        $this->assertEquals("sharedSecret", $subscription->getSharedSecret());
     }
 
     public function testConstructFull()
     {
-        $subscription = new Subscription("http://toto.com", "publicKey", "authToken", "aes128gcm");
+        $subscription = new Subscription("http://toto.com", "publicKey", "authToken", "aes128gcm", "sharedSecret");
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
         $this->assertEquals("aes128gcm", $subscription->getContentEncoding());
+        $this->assertEquals("sharedSecret", $subscription->getSharedSecret());
     }
 
     public function testCreatePartialWithNewStructure()
@@ -101,5 +106,21 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
         $this->assertEquals("aes128gcm", $subscription->getContentEncoding());
+    }
+
+    public function testCreatePartialWithNewStructureAndSharedSecret()
+    {
+        $subscription = Subscription::create([
+            "endpoint" => "http://toto.com",
+            "sharedSecret" => 'sharedSecret',
+            "keys" => [
+                'p256dh' => 'publicKey',
+                'auth' => 'authToken'
+            ]
+        ]);
+        $this->assertEquals("http://toto.com", $subscription->getEndpoint());
+        $this->assertEquals("publicKey", $subscription->getPublicKey());
+        $this->assertEquals("authToken", $subscription->getAuthToken());
+        $this->assertEquals("sharedSecret", $subscription->getSharedSecret());
     }
 }

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -19,6 +19,7 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
     private static $endpoints;
     private static $keys;
     private static $tokens;
+    private static $secret;
 
     /** @var WebPush WebPush with correct api keys */
     private $webPush;
@@ -39,6 +40,10 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
         self::$tokens = [
             'standard' => getenv('USER_AUTH_TOKEN'),
         ];
+
+        self::$secret = [
+            'standard' => getenv('USER_SHARED_SECRET'),
+        ];
     }
 
     /**
@@ -52,6 +57,9 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
             'USER_AUTH_TOKEN',
             'VAPID_PUBLIC_KEY',
             'VAPID_PRIVATE_KEY',
+            'LOCAL_PUBLIC_KEY',
+            'LOCAL_PRIVATE_KEY',
+            'USER_SHARED_SECRET',
         ];
         foreach ($envs as $env) {
             if (!getenv($env)) {
@@ -67,6 +75,7 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
             ],
         ]);
         $this->webPush->setAutomaticPadding(false); // disable automatic padding in tests to speed these up
+        $this->webPush->setLocalKeys(getenv('LOCAL_PUBLIC_KEY'),getenv('LOCAL_PRIVATE_KEY'));
     }
 
     /**
@@ -81,7 +90,7 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
         if (getenv('CI')) return [];
 
         return [
-            [new Subscription(self::$endpoints['standard'], self::$keys['standard'], self::$tokens['standard']), '{"message":"Comment ça va ?","tag":"general"}'],
+            [new Subscription(self::$endpoints['standard'], self::$keys['standard'], self::$tokens['standard'], null, self::$secret['standard']), '{"message":"Comment ça va ?","tag":"general"}'],
         ];
     }
 


### PR DESCRIPTION
This pull request adds the ability to generate the local keys before hand and provide them to the WebPush client. This way it does not generate a new local key object for each notification.

This also opens the possibility to generate the shared secret before hand so that this is also skipped when you send the notification.

Here is an example:

**Generate the local public and private key and store them**
```php
use Jose\Component\Core\Util\Ecc\NistCurve;
use Minishlink\WebPush\Encryption;
use Minishlink\WebPush\Utils;
use Base64Url\Base64Url;

[$localPublicKeyObject, $localPrivateKeyObject] = Encryption::createLocalKeyObject();

// Store these variables
$localPublicKey = Base64Url::encode(Utils::serializePublicKey($localPublicKeyObject));
$localPrivateKey = Base64Url::encode(Utils::serializePrivateKey($localPrivateKeyObject));
```
**When a user subscribes we generate the shared secret and store it with all the other info**
```php
use Minishlink\WebPush\Encryption;
use Minishlink\WebPush\Utils;
use Base64Url\Base64Url;

$localPrivateKey = Base64Url::decode('storedLocalPrivateKey');
$userPublicKey = "TheUsersPublicKey";

// Store the shared secret with the subscription
$sharedSecret = Encryption::createSharedSecret($userPublicKey, Utils::unserializePrivateKey($localPrivateKey));
```

**When you want to send a notification**
```php
use Minishlink\WebPush\Encryption;
use Minishlink\WebPush\Utils;
use Base64Url\Base64Url;

$localPublicKey = 'storedLocalPublicKey';
$localPrivateKey = 'storedLocalPrivateKey';

$webPush = new WebPush();
$webPush->setLocalKeys($localPublicKey, $localPrivateKey);

$endpoint = 'endpoint'; // From your data store
$publicKey = 'publicKey'; // From your data store
$authToken = 'authToken'; // From your data store
$contentEncoding= 'contentEncoding'; // From your data store
$sharedSecret = 'sharedSecret'; // From your data store, previously created

$subscriptions = new Subscription($endpoint, $publicKey, $authToken, $contentEncoding, $sharedSecret);

$webPush->sendNotification($subscription, '{"test":"payload"}');
```