### PR TITLE
Use native PHP 7.3 scalar multiplication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
     include:
         - php: 7.1
         - php: 7.2
+        - php: 7.3
         - php: nightly
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,15 @@ sudo: required
 cache:
   directories:
     - ~/.selenium-assistant
-    - node_modules                  # cache modules too
-    - $HOME/.composer/cache/files   # and composer packages
+    - node_modules            # cache modules too
+    - $HOME/.composer/cache   # and composer packages
+    - vendor
 
-matrix:
-    allow_failures:
-        - php: nightly
-    fast_finish: true
-    include:
-        - php: 7.1
-        - php: 7.2
-        - php: 7.3
-        - php: nightly
+php:
+    - 7.1
+    - 7.2
+    - 7.3
+    - nightly
 
 env:
   - TRAVIS_NODE_VERSION="stable"
@@ -40,5 +37,26 @@ script:
   - web-push-testing-service start example -p 9012
   - composer test:unit
   - web-push-testing-service stop example
-  - composer test:typing
-  - composer test:syntax
+
+jobs:
+    allow_failures:
+        - php: nightly
+
+    include:
+        - stage: Metrics and quality
+          env: STATIC_ANALYSIS
+          script:
+              - composer test:typing
+
+        - stage: Metrics and quality
+          env: CODING_STANDARDS
+          script:
+              - composer test:syntax
+
+        - stage: Security Check
+          env: SECURITY_CHECK
+          before_script:
+              - wget -c https://get.sensiolabs.org/security-checker.phar
+              - chmod +x security-checker.phar
+          script:
+              - ./security-checker.phar security:check

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "test:unit": "./vendor/bin/phpunit --color",
-    "test:typing": "./vendor/bin/phpstan analyse --level max src",
+    "test:typing": "./vendor/bin/phpstan analyse",
     "test:syntax": "./vendor/bin/php-cs-fixer fix ./src --dry-run --stop-on-violation --using-cache=no"
   },
   "require": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: 7
+    paths:
+        - src

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -334,8 +334,12 @@ class Encryption
         );
 
         $sharedSecret = $curve->mul($userPublicKeyObject->getPoint(), $privateKey->getSecret())->getX();
+        $sharedSecret = hex2bin(str_pad(gmp_strval($sharedSecret, 16), 64, '0', STR_PAD_LEFT));
+        if (false === $sharedSecret) {
+            throw new \ErrorException('Failed to convert shared secret from hexadecimal to binary');
+        }
 
-        return hex2bin(str_pad(gmp_strval($sharedSecret, 16), 64, '0', STR_PAD_LEFT));
+        return $sharedSecret;
     }
 
     /**
@@ -365,7 +369,8 @@ class Encryption
     }
 
     /**
-     * @param string $key
+     * @param string $publicKey
+     * @param PrivateKey $secret
      *
      * @return string
      */


### PR DESCRIPTION
This PR changes the way the shared secret is computed.
If the function `openssl_pkey_derive` is available (PHP7.3), then it is used. The computation process is approx 50x faster.

Pure PHP function used as a fallback.

This PR fixes #149 