### PR TITLE
Suppress HTTP error exceptions

### DIFF
--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -98,6 +98,11 @@ class WebPush
         if (!array_key_exists('timeout', $clientOptions) && isset($timeout)) {
             $clientOptions['timeout'] = $timeout;
         }
+
+        if (!array_key_exists('http_errors', $clientOptions)) {
+            $clientOptions['http_errors'] = false;
+        }
+
         $this->client = new Client($clientOptions);
     }
 

--- a/tests/PushServiceTest.php
+++ b/tests/PushServiceTest.php
@@ -44,7 +44,7 @@ final class PushServiceTest extends PHPUnit\Framework\TestCase
      */
     protected function setUp()
     {
-        if (!(getenv('TRAVIS') || getenv('CI'))) {
+        if (getenv('TRAVIS') || getenv('CI')) {
             $this->markTestSkipped('This test does not run on Travis.');
         }
 


### PR DESCRIPTION
Unless explicitly overridden, the default behavior of the HTTP client should be to suppress HTTP errors. While it would make sense to make this not only default, but forced, there still may be use cases in development environments and debugging scenarios that may make sense to allow this to be a configurable option.

directly fixes #197 and issues surrounding unusability due to erroneous, malicious, expired subscriptions.