### PR TITLE
Upgrade web-token dependency to version ^2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
         - php: nightly
     fast_finish: true
     include:
-        - php: 7.1
         - php: 7.2
         - php: 7.3
         - php: nightly

--- a/README.md
+++ b/README.md
@@ -10,17 +10,16 @@ As it is standardized, you don't have to worry about what server type it relies 
 
 ## Requirements
 
-* PHP 7.1+
-  * gmp
-  * mbstring
-  * curl
-  * openssl
-
-PHP 7.2+ is recommended for better performance.
+PHP 7.2+ and the following extensions:
+ * gmp
+ * mbstring
+ * curl
+ * openssl
 
 There is no support and maintenance for older PHP versions, however you are free to use the following compatible versions:
 - PHP 5.6 or HHVM: `v1.x`
 - PHP 7.0: `v2.x`
+- PHP 7.1: `v3.x-v5.x`
 
 ## Installation
 Use [composer](https://getcomposer.org/) to download and install the library and its dependencies.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
     "lib-openssl": "*",
     "guzzlehttp/guzzle": "^6.2",
     "web-token/jwt-signature": "^2.0",
-    "web-token/jwt-key-mgmt": "^2.0"
+    "web-token/jwt-key-mgmt": "^2.0",
+    "web-token/jwt-signature-algorithm-ecdsa": "^2.0",
+    "web-token/jwt-util-ecc": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "test:syntax": "./vendor/bin/php-cs-fixer fix ./src --dry-run --stop-on-violation --using-cache=no"
   },
   "require": {
-    "php": "^7.1",
+    "php": "^7.2",
     "ext-json": "*",
     "ext-gmp": "*",
     "lib-openssl": "*",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "ext-gmp": "*",
     "lib-openssl": "*",
     "guzzlehttp/guzzle": "^6.2",
-    "web-token/jwt-signature": "^1.0",
-    "web-token/jwt-key-mgmt": "^1.0"
+    "web-token/jwt-signature": "^2.0",
+    "web-token/jwt-key-mgmt": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0",

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -285,7 +285,7 @@ class Encryption
         }
 
         return [
-            PublicKey::create(Point::create(
+            new PublicKey(Point::create(
                 gmp_init(bin2hex($details['ec']['x']), 16),
                 gmp_init(bin2hex($details['ec']['y']), 16)
             )),

--- a/src/VAPID.php
+++ b/src/VAPID.php
@@ -15,7 +15,6 @@ namespace Minishlink\WebPush;
 
 use Base64Url\Base64Url;
 use Jose\Component\Core\AlgorithmManager;
-use Jose\Component\Core\Converter\StandardConverter;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Ecc\NistCurve;
 use Jose\Component\Core\Util\Ecc\Point;
@@ -56,7 +55,7 @@ class VAPID
             if ($jwk->get('kty') !== 'EC' || !$jwk->has('d') || !$jwk->has('x') || !$jwk->has('y')) {
                 throw new \ErrorException('Invalid PEM data.');
             }
-            $publicKey = PublicKey::create(Point::create(
+            $publicKey = new PublicKey(Point::create(
                 gmp_init(bin2hex(Base64Url::decode($jwk->get('x'))), 16),
                 gmp_init(bin2hex(Base64Url::decode($jwk->get('y'))), 16)
             ));
@@ -132,7 +131,7 @@ class VAPID
         }
 
         list($x, $y) = Utils::unserializePublicKey($publicKey);
-        $jwk = JWK::create([
+        $jwk = new JWK([
             'kty' => 'EC',
             'crv' => 'P-256',
             'x' => Base64Url::encode($x),
@@ -140,9 +139,8 @@ class VAPID
             'd' => Base64Url::encode($privateKey),
         ]);
 
-        $jsonConverter = new StandardConverter();
-        $jwsCompactSerializer = new CompactSerializer($jsonConverter);
-        $jwsBuilder = new JWSBuilder($jsonConverter, AlgorithmManager::create([new ES256()]));
+        $jwsCompactSerializer = new CompactSerializer();
+        $jwsBuilder = new JWSBuilder(new AlgorithmManager([new ES256()]));
         $jws = $jwsBuilder
             ->create()
             ->withPayload($jwtPayload)


### PR DESCRIPTION
This breaks BC with PHP 7.1, as `web-token` 2.0 requires PHP >= 7.2.

Release `minishlink/web-push:6.0.0`?