### PR TITLE
Update VAPID.php

### DIFF
--- a/src/VAPID.php
+++ b/src/VAPID.php
@@ -27,8 +27,8 @@ use Jose\Component\Signature\Serializer\CompactSerializer;
 
 class VAPID
 {
-    private const PUBLIC_KEY_LENGTH = 65;
-    private const PRIVATE_KEY_LENGTH = 32;
+    const PUBLIC_KEY_LENGTH = 65;
+    const PRIVATE_KEY_LENGTH = 32;
 
     /**
      * @param array $vapid


### PR DESCRIPTION
const should not specify access level 
https://www.php.net/manual/en/language.oop5.constants.php

else php >7.1 will throw 
syntax error, unexpected 'const' (T_CONST), expecting variable (T_VARIABLE) ...