### PR TITLE
Update WebPush.php

### DIFF
--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -21,8 +21,8 @@ use Psr\Http\Message\ResponseInterface;
 
 class WebPush
 {
-    public const GCM_URL = 'https://android.googleapis.com/gcm/send';
-    public const FCM_BASE_URL = 'https://fcm.googleapis.com';
+    const GCM_URL = 'https://android.googleapis.com/gcm/send';
+    const FCM_BASE_URL = 'https://fcm.googleapis.com';
 
     /**
      * @var Client


### PR DESCRIPTION
const should not specify access level 
https://www.php.net/manual/en/language.oop5.constants.php

else php >7.1 will throw 
syntax error, unexpected 'const' (T_CONST), expecting variable (T_VARIABLE) ...