### PR TITLE
Update Encryption.php

### DIFF
--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -21,8 +21,8 @@ use Jose\Component\Core\Util\Ecc\PublicKey;
 
 class Encryption
 {
-    public const MAX_PAYLOAD_LENGTH = 4078;
-    public const MAX_COMPATIBILITY_PAYLOAD_LENGTH = 3052;
+    const MAX_PAYLOAD_LENGTH = 4078;
+    const MAX_COMPATIBILITY_PAYLOAD_LENGTH = 3052;
 
     /**
      * @param string $payload


### PR DESCRIPTION
const should not specify access level 
https://www.php.net/manual/en/language.oop5.constants.php

else php >7.1 will throw 
syntax error, unexpected 'const' (T_CONST), expecting variable (T_VARIABLE) ...