### PR TITLE
Fix CI detection to fix Travis tests

### DIFF
--- a/tests/PushServiceTest.php
+++ b/tests/PushServiceTest.php
@@ -44,7 +44,7 @@ final class PushServiceTest extends PHPUnit\Framework\TestCase
      */
     protected function setUp()
     {
-        if (!(getenv('TRAVIS') || getenv('CI'))) {
+        if (getenv('TRAVIS') || getenv('CI')) {
             $this->markTestSkipped('This test does not run on Travis.');
         }
 


### PR DESCRIPTION
Debugging `GoogleChromeLabs/web-push-testing-service` is a pain in the ass and there seems to be logic to skip tests that use it.

This PR fixes the logic that is used to detect CI and skip these tests.