### PR TITLE
Adding a Wordpress plugin that uses this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ The following are available:
     - [MinishlinkWebPushBundle](https://github.com/Minishlink/web-push-bundle)
     - [bentools/webpush-bundle](https://github.com/bpolaszek/webpush-bundle) (associate your Symfony users to WebPush subscriptions)
 - Laravel: [laravel-notification-channels/webpush](https://github.com/laravel-notification-channels/webpush)
+- WordPress plugin: [Perfecty Push Notifications](https://github.com/rwngallego/perfecty-push-wp/)
 
 Feel free to add your own!
 


### PR DESCRIPTION
I'm the author of [Perfecty Push Notifications](https://github.com/rwngallego/perfecty-push-wp/), an Open Source plugin for WordPress, and I'm adding this for those who would like their WordPress sites to have a self-hosted Push Notifications implementation using this PHP library.