### PR TITLE
Fix: openssl_pkey_free is deprecated for PHP 8

### DIFF
--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -313,7 +313,9 @@ class Encryption
         }
 
         $details = openssl_pkey_get_details($keyResource);
-        openssl_pkey_free($keyResource);
+        if (PHP_MAJOR_VERSION < 8) {
+            openssl_pkey_free($keyResource);
+        }
 
         if (!$details) {
             throw new \RuntimeException('Unable to get the key details');


### PR DESCRIPTION
Fixed #311

Some projects using PHP 8 are broken because of this deprecated function. This PR will fix that.