### PR TITLE
Add #[\ReturnTypeWillChange] attribute for PHP 8.x compatibility.

### DIFF
--- a/src/MessageSentReport.php
+++ b/src/MessageSentReport.php
@@ -168,6 +168,7 @@ class MessageSentReport implements \JsonSerializable
     /**
      * @return array|mixed
      */
+	#[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/MessageSentReport.php
+++ b/src/MessageSentReport.php
@@ -168,7 +168,7 @@ class MessageSentReport implements \JsonSerializable
     /**
      * @return array|mixed
      */
-	#[\ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [


### PR DESCRIPTION
Starting with PHP 8.1 the `JsonSerializable` interface has a return type of `mixed` for its `jsonSerialize` method which is implemented in `Minishlink\WebPush\MessageSentReport`.

Adding a return type of `mixed` will break the library in all versions before PHP 8.1. Not making any changes will break the library in PHP 8.1.

However, adding the attribute `#[\ReturnTypeWillChange]` allows us to make no further changes but ensure the library will still work in all existing versions AND PHP 8.1.

The attribute is entirely ignored in non-supporting PHP versions.

So, as per the contributing guidelines this has not been tested but you can see for yourself it does not in the slightest change the functionality so should be good to merge.

Note: There needs to be similar changes in the JWT libraries but I'll be doing some PRs for those too shortly.

Cheers!