### PR TITLE
An alternative approach for PHP 8.1 support

### DIFF
--- a/src/MessageSentReport.php
+++ b/src/MessageSentReport.php
@@ -168,6 +168,7 @@ class MessageSentReport implements \JsonSerializable
     /**
      * @return array|mixed
      */
+	#[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/MessageSentReport.php
+++ b/src/MessageSentReport.php
@@ -166,10 +166,9 @@ class MessageSentReport implements \JsonSerializable
     }
 
     /**
-     * @return array|mixed
+     * @return array
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'success'  => $this->isSuccess(),

--- a/src/MessageSentReport.php
+++ b/src/MessageSentReport.php
@@ -168,7 +168,7 @@ class MessageSentReport implements \JsonSerializable
     /**
      * @return array|mixed
      */
-	#[\ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [


### PR DESCRIPTION
@Minishlink I am so sorry seeing as you already (very efficiently!) merged my previous PR.

There is an alternative approach. I'm not exaggerating when I say I've spent the last 24 hours engrossed in various vendor libraries looking at this kind of stuff with a view to supporting all PHP versions from 7.0 to 8.1 in our application and it's starting to affect my ability to make correct decisions! 

PHP 8.1 adds a return type of `mixed` to the `JsonSerializable::jsonSerialize` method. While the `#[\ReturnTypeWillChange]` attribute will work, an alternative is to simply add the `array` return type.

This will work on all PHP versions you support and still work on PHP 8.1 because `array` is a more specific type than `mixed` (which is a union type that consists of many types, including `array`).

So, nothing wrong with the previous approach but this may be preferred. No issue if you decide to close this in favour of sticking with the original approach.