### PR TITLE
Dropped support for PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ cache:
 
 jobs:
   include:
-    - php: 7.2
     - php: 7.3
     - php: 7.4
     - php: nightly

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ As it is standardized, you don't have to worry about what server type it relies 
 
 ## Requirements
 
-PHP 7.2+ and the following extensions:
+PHP 7.3+ and the following extensions:
  * gmp (optional but better for performance)
  * mbstring
  * curl
@@ -322,7 +322,7 @@ Internally, WebPush uses the [WebToken](https://github.com/web-token) framework 
 ### How do I scale?
 Here are some ideas:
 
-1. Upgrade to PHP 7.2
+1. Upgrade to PHP 7.3
 2. Make sure MultiCurl is available on your server
 3. Find the right balance for your needs between security and performance (see above)
 4. Find the right batch size (set it in `defaultOptions` or as parameter to `flush()`)
@@ -344,11 +344,6 @@ Make sure to require Composer's [autoloader](https://getcomposer.org/doc/01-basi
 ```php
 require __DIR__ . '/path/to/vendor/autoload.php';
 ```
-
-### I must use PHP 5.4 or 5.5. What can I do?
-You won't be able to send any payload, so you'll only be able to use `sendOneNotification($subscription)` or `queueNotification($subscription)`.
-Install the library with `composer` using `--ignore-platform-reqs`.
-The workaround for getting the payload is to fetch it in the service worker ([example](https://github.com/Minishlink/physbook/blob/2ed8b9a8a217446c9747e9191a50d6312651125d/web/service-worker.js#L75)). 
 
 ### I lost my VAPID keys!
 See [issue #58](https://github.com/web-push-libs/web-push-php/issues/58).

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "test:syntax": "./vendor/bin/php-cs-fixer fix ./src --dry-run --stop-on-violation --using-cache=no"
   },
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.3",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*",

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -26,9 +26,6 @@ class Encryption
     public const MAX_COMPATIBILITY_PAYLOAD_LENGTH = 3052;
 
     /**
-     * @param string $payload
-     * @param int $maxLengthToPad
-     * @param string $contentEncoding
      * @return string padded payload (plaintext)
      * @throws \ErrorException
      */
@@ -50,8 +47,6 @@ class Encryption
      * @param string $payload With padding
      * @param string $userPublicKey Base 64 encoded (MIME or URL-safe)
      * @param string $userAuthToken Base 64 encoded (MIME or URL-safe)
-     * @param string $contentEncoding
-     * @return array
      *
      * @throws \ErrorException
      */
@@ -68,14 +63,6 @@ class Encryption
     }
 
     /**
-     * @param string $payload
-     * @param string $userPublicKey
-     * @param string $userAuthToken
-     * @param string $contentEncoding
-     * @param array $localKeyObject
-     * @param string $salt
-     * @return array
-     *
      * @throws \ErrorException
      */
     public static function deterministicEncrypt(string $payload, string $userPublicKey, string $userAuthToken, string $contentEncoding, array $localKeyObject, string $salt): array
@@ -90,7 +77,7 @@ class Encryption
             $localPublicKey = hex2bin(Utils::serializePublicKeyFromJWK($localJwk));
         } else {
             /** @var PrivateKey $localPrivateKeyObject */
-            list($localPublicKeyObject, $localPrivateKeyObject) = $localKeyObject;
+            [$localPublicKeyObject, $localPrivateKeyObject] = $localKeyObject;
             $localPublicKey = hex2bin(Utils::serializePublicKey($localPublicKeyObject));
             $localJwk = new JWK([
                 'kty' => 'EC',
@@ -178,8 +165,6 @@ class Encryption
      * @param string $ikm    Input keying material
      * @param string $info   Application-specific context
      * @param int    $length The length (in bytes) of the required output key
-     *
-     * @return string
      */
     private static function hkdf(string $salt, string $ikm, string $info, int $length): string
     {
@@ -198,8 +183,6 @@ class Encryption
      *
      * @param string $clientPublicKey The client's public key
      * @param string $serverPublicKey Our public key
-     *
-     * @return null|string
      *
      * @throws \ErrorException
      */
@@ -230,8 +213,6 @@ class Encryption
      *
      * @param string $type The type of the info record
      * @param string|null $context The context for the record
-     * @param string $contentEncoding
-     * @return string
      *
      * @throws \ErrorException
      */
@@ -254,9 +235,6 @@ class Encryption
         throw new \ErrorException('This content encoding is not supported.');
     }
 
-    /**
-     * @return array
-     */
     private static function createLocalKeyObject(): array
     {
         try {
@@ -266,9 +244,6 @@ class Encryption
         }
     }
 
-    /**
-     * @return array
-     */
     private static function createLocalKeyObjectUsingPurePhpMethod(): array
     {
         $curve = NistCurve::curve256();
@@ -298,9 +273,6 @@ class Encryption
         ];
     }
 
-    /**
-     * @return array
-     */
     private static function createLocalKeyObjectUsingOpenSSL(): array
     {
         $keyResource = openssl_pkey_new([
@@ -333,12 +305,6 @@ class Encryption
     }
 
     /**
-     * @param string $userAuthToken
-     * @param string $userPublicKey
-     * @param string $localPublicKey
-     * @param string $sharedSecret
-     * @param string $contentEncoding
-     * @return string
      * @throws \ErrorException
      */
     private static function getIKM(string $userAuthToken, string $userPublicKey, string $localPublicKey, string $sharedSecret, string $contentEncoding): string
@@ -396,10 +362,6 @@ class Encryption
         }
     }
 
-    /**
-     * @param string $value
-     * @return BigInteger
-     */
     private static function convertBase64ToBigInteger(string $value): BigInteger
     {
         $value = unpack('H*', Base64Url::decode($value));
@@ -407,10 +369,6 @@ class Encryption
         return BigInteger::fromBase($value[1], 16);
     }
 
-    /**
-     * @param string $value
-     * @return \GMP
-     */
     private static function convertBase64ToGMP(string $value): \GMP
     {
         $value = unpack('H*', Base64Url::decode($value));

--- a/src/MessageSentReport.php
+++ b/src/MessageSentReport.php
@@ -14,7 +14,6 @@ use Psr\Http\Message\ResponseInterface;
  */
 class MessageSentReport implements \JsonSerializable
 {
-
     /**
      * @var boolean
      */
@@ -36,10 +35,7 @@ class MessageSentReport implements \JsonSerializable
     protected $reason;
 
     /**
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     * @param bool              $success
-     * @param string            $reason
+     * @param string $reason
      */
     public function __construct(RequestInterface $request, ?ResponseInterface $response = null, bool $success = true, $reason = 'OK')
     {
@@ -49,74 +45,44 @@ class MessageSentReport implements \JsonSerializable
         $this->reason   = $reason;
     }
 
-    /**
-     * @return bool
-     */
     public function isSuccess(): bool
     {
         return $this->success;
     }
 
-    /**
-     * @param bool $success
-     *
-     * @return MessageSentReport
-     */
     public function setSuccess(bool $success): MessageSentReport
     {
         $this->success = $success;
         return $this;
     }
 
-    /**
-     * @return RequestInterface
-     */
     public function getRequest(): RequestInterface
     {
         return $this->request;
     }
 
-    /**
-     * @param RequestInterface $request
-     *
-     * @return MessageSentReport
-     */
     public function setRequest(RequestInterface $request): MessageSentReport
     {
         $this->request = $request;
         return $this;
     }
 
-    /**
-     * @return ResponseInterface | null
-     */
     public function getResponse(): ?ResponseInterface
     {
         return $this->response;
     }
 
-    /**
-     * @param ResponseInterface $response
-     *
-     * @return MessageSentReport
-     */
     public function setResponse(ResponseInterface $response): MessageSentReport
     {
         $this->response = $response;
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getEndpoint(): string
     {
         return $this->request->getUri()->__toString();
     }
 
-    /**
-     * @return bool
-     */
     public function isSubscriptionExpired(): bool
     {
         if (!$this->response) {
@@ -126,36 +92,22 @@ class MessageSentReport implements \JsonSerializable
         return \in_array($this->response->getStatusCode(), [404, 410], true);
     }
 
-    /**
-     * @return string
-     */
     public function getReason(): string
     {
         return $this->reason;
     }
 
-    /**
-     * @param string $reason
-     *
-     * @return MessageSentReport
-     */
     public function setReason(string $reason): MessageSentReport
     {
         $this->reason = $reason;
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getRequestPayload(): string
     {
         return $this->request->getBody()->getContents();
     }
 
-    /**
-     * @return string | null
-     */
     public function getResponseContent(): ?string
     {
         if (!$this->response) {
@@ -165,9 +117,6 @@ class MessageSentReport implements \JsonSerializable
         return $this->response->getBody()->getContents();
     }
 
-    /**
-     * @return array
-     */
     public function jsonSerialize(): array
     {
         return [

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -27,14 +27,6 @@ class Notification
     /** @var array Auth details : VAPID */
     private $auth;
 
-    /**
-     * Notification constructor.
-     *
-     * @param SubscriptionInterface $subscription
-     * @param null|string $payload
-     * @param array $options
-     * @param array $auth
-     */
     public function __construct(SubscriptionInterface $subscription, ?string $payload, array $options, array $auth)
     {
         $this->subscription = $subscription;
@@ -43,27 +35,16 @@ class Notification
         $this->auth = $auth;
     }
 
-    /**
-     * @return SubscriptionInterface
-     */
     public function getSubscription(): SubscriptionInterface
     {
         return $this->subscription;
     }
 
-    /**
-     * @return null|string
-     */
     public function getPayload(): ?string
     {
         return $this->payload;
     }
 
-    /**
-     * @param array $defaultOptions
-     *
-     * @return array
-     */
     public function getOptions(array $defaultOptions = []): array
     {
         $options = $this->options;
@@ -74,11 +55,6 @@ class Notification
         return $options;
     }
 
-    /**
-     * @param array $defaultAuth
-     *
-     * @return array
-     */
     public function getAuth(array $defaultAuth): array
     {
         return count($this->auth) > 0 ? $this->auth : $defaultAuth;

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -28,12 +28,7 @@ class Subscription implements SubscriptionInterface
     private $contentEncoding;
 
     /**
-     * Subscription constructor.
-     *
-     * @param string $endpoint
-     * @param null|string $publicKey
-     * @param null|string $authToken
-     * @param string $contentEncoding (Optional) Must be "aesgcm"
+     * @param string|null $contentEncoding (Optional) Must be "aesgcm"
      * @throws \ErrorException
      */
     public function __construct(
@@ -57,10 +52,7 @@ class Subscription implements SubscriptionInterface
     }
 
     /**
-     * Subscription factory.
-     *
      * @param array $associativeArray (with keys endpoint, publicKey, authToken, contentEncoding)
-     * @return self
      * @throws \ErrorException
      */
     public static function create(array $associativeArray): self

--- a/src/SubscriptionInterface.php
+++ b/src/SubscriptionInterface.php
@@ -18,23 +18,11 @@ namespace Minishlink\WebPush;
  */
 interface SubscriptionInterface
 {
-    /**
-     * @return string
-     */
     public function getEndpoint(): string;
 
-    /**
-     * @return null|string
-     */
     public function getPublicKey(): ?string;
 
-    /**
-     * @return null|string
-     */
     public function getAuthToken(): ?string;
 
-    /**
-     * @return null|string
-     */
     public function getContentEncoding(): ?string;
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -20,21 +20,11 @@ use Jose\Component\Core\Util\Ecc\PublicKey;
 
 class Utils
 {
-    /**
-     * @param string $value
-     *
-     * @return int
-     */
     public static function safeStrlen(string $value): int
     {
         return mb_strlen($value, '8bit');
     }
 
-    /**
-     * @param PublicKey $publicKey
-     *
-     * @return string
-     */
     public static function serializePublicKey(PublicKey $publicKey): string
     {
         $hexString = '04';
@@ -50,11 +40,6 @@ class Utils
         return $hexString;
     }
 
-    /**
-     * @param JWK $jwk
-     *
-     * @return string
-     */
     public static function serializePublicKeyFromJWK(JWK $jwk): string
     {
         $hexString = '04';
@@ -64,11 +49,6 @@ class Utils
         return $hexString;
     }
 
-    /**
-     * @param string $data
-     *
-     * @return array
-     */
     public static function unserializePublicKey(string $data): array
     {
         $data = bin2hex($data);

--- a/src/VAPID.php
+++ b/src/VAPID.php
@@ -27,10 +27,6 @@ class VAPID
     private const PRIVATE_KEY_LENGTH = 32;
 
     /**
-     * @param array $vapid
-     *
-     * @return array
-     *
      * @throws \ErrorException
      */
     public static function validate(array $vapid): array
@@ -96,7 +92,6 @@ class VAPID
      * @param string $subject This should be a URL or a 'mailto:' email address
      * @param string $publicKey The decoded VAPID public key
      * @param string $privateKey The decoded VAPID private key
-     * @param string $contentEncoding
      * @param null|int $expiration The expiration of the VAPID JWT. (UNIX timestamp)
      *
      * @return array Returns an array with the 'Authorization' and 'Crypto-Key' values to be used as headers
@@ -123,7 +118,7 @@ class VAPID
             throw new \ErrorException('Failed to encode JWT payload in JSON');
         }
 
-        list($x, $y) = Utils::unserializePublicKey($publicKey);
+        [$x, $y] = Utils::unserializePublicKey($publicKey);
         $jwk = new JWK([
             'kty' => 'EC',
             'crv' => 'P-256',
@@ -148,7 +143,9 @@ class VAPID
                 'Authorization' => 'WebPush '.$jwt,
                 'Crypto-Key' => 'p256ecdsa='.$encodedPublicKey,
             ];
-        } elseif ($contentEncoding === 'aes128gcm') {
+        }
+
+        if ($contentEncoding === 'aes128gcm') {
             return [
                 'Authorization' => 'vapid t='.$jwt.', k='.$encodedPublicKey,
             ];
@@ -161,7 +158,6 @@ class VAPID
      * This method creates VAPID keys in case you would not be able to have a Linux bash.
      * DO NOT create keys at each initialization! Save those keys and reuse them.
      *
-     * @return array
      * @throws \ErrorException
      */
     public static function createVapidKeys(): array

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -62,7 +62,6 @@ class WebPush
      * @param array    $auth           Some servers needs authentication
      * @param array    $defaultOptions TTL, urgency, topic, batchSize
      * @param int|null $timeout        Timeout of POST request
-     * @param array    $clientOptions
      *
      * @throws \ErrorException
      */
@@ -101,11 +100,9 @@ class WebPush
     /**
      * Queue a notification. Will be sent when flush() is called.
      *
-     * @param SubscriptionInterface $subscription
      * @param string|null $payload If you want to send an array or object, json_encode it
      * @param array $options Array with several options tied to this notification. If not set, will use the default options that you can set in the WebPush object
      * @param array $auth Use this auth details instead of what you provided when creating WebPush
-     *
      * @throws \ErrorException
      */
     public function queueNotification(SubscriptionInterface $subscription, ?string $payload = null, array $options = [], array $auth = []): void
@@ -131,11 +128,9 @@ class WebPush
     }
 
     /**
-     * @param SubscriptionInterface $subscription
      * @param string|null $payload If you want to send an array or object, json_encode it
      * @param array $options Array with several options tied to this notification. If not set, will use the default options that you can set in the WebPush object
      * @param array $auth Use this auth details instead of what you provided when creating WebPush
-     * @return MessageSentReport
      * @throws \ErrorException
      */
     public function sendOneNotification(SubscriptionInterface $subscription, ?string $payload = null, array $options = [], array $auth = []): MessageSentReport
@@ -154,7 +149,7 @@ class WebPush
      */
     public function flush(?int $batchSize = null): \Generator
     {
-        if (null === $this->notifications || empty($this->notifications)) {
+        if (empty($this->notifications)) {
             yield from [];
             return;
         }
@@ -202,10 +197,6 @@ class WebPush
     }
 
     /**
-     * @param array $notifications
-     *
-     * @return array
-     *
      * @throws \ErrorException
      */
     protected function prepare(array $notifications): array
@@ -289,9 +280,6 @@ class WebPush
         return $requests;
     }
 
-    /**
-     * @return bool
-     */
     public function isAutomaticPadding(): bool
     {
         return $this->automaticPadding !== 0;
@@ -307,8 +295,6 @@ class WebPush
 
     /**
      * @param int|bool $automaticPadding Max padding length
-     *
-     * @return WebPush
      *
      * @throws \Exception
      */
@@ -339,7 +325,6 @@ class WebPush
 
     /**
      * Reuse VAPID headers in the same flush session to improve performance
-     * @param bool $enabled
      *
      * @return WebPush
      */
@@ -350,9 +335,6 @@ class WebPush
         return $this;
     }
 
-    /**
-     * @return array
-     */
     public function getDefaultOptions(): array
     {
         return $this->defaultOptions;
@@ -365,26 +347,20 @@ class WebPush
      */
     public function setDefaultOptions(array $defaultOptions)
     {
-        $this->defaultOptions['TTL'] = isset($defaultOptions['TTL']) ? $defaultOptions['TTL'] : 2419200;
-        $this->defaultOptions['urgency'] = isset($defaultOptions['urgency']) ? $defaultOptions['urgency'] : null;
-        $this->defaultOptions['topic'] = isset($defaultOptions['topic']) ? $defaultOptions['topic'] : null;
-        $this->defaultOptions['batchSize'] = isset($defaultOptions['batchSize']) ? $defaultOptions['batchSize'] : 1000;
+        $this->defaultOptions['TTL'] = $defaultOptions['TTL'] ?? 2419200;
+        $this->defaultOptions['urgency'] = $defaultOptions['urgency'] ?? null;
+        $this->defaultOptions['topic'] = $defaultOptions['topic'] ?? null;
+        $this->defaultOptions['batchSize'] = $defaultOptions['batchSize'] ?? 1000;
 
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function countPendingNotifications(): int
     {
         return null !== $this->notifications ? count($this->notifications) : 0;
     }
 
     /**
-     * @param string $audience
-     * @param string $contentEncoding
-     * @param array $vapid
      * @return array
      * @throws \ErrorException
      */

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -80,9 +80,6 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
     /**
      * @dataProvider payloadProvider
      *
-     * @param string $payload
-     * @param int $maxLengthToPad
-     * @param int $expectedResLength
      * @throws ErrorException
      */
     public function testPadPayload(string $payload, int $maxLengthToPad, int $expectedResLength)
@@ -93,9 +90,6 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expectedResLength, Utils::safeStrlen($res));
     }
 
-    /**
-     * @return array
-     */
     public function payloadProvider(): array
     {
         return [

--- a/tests/MessageSentReportTest.php
+++ b/tests/MessageSentReportTest.php
@@ -14,17 +14,12 @@ use \GuzzleHttp\Psr7\Response;
 class MessageSentReportTest extends \PHPUnit\Framework\TestCase {
 
 	/**
-	 * @param MessageSentReport $report
-	 * @param bool              $expected
 	 * @dataProvider generateReportsWithExpiration
 	 */
 	public function testIsSubscriptionExpired(MessageSentReport $report, bool $expected): void {
 		$this->assertEquals($expected, $report->isSubscriptionExpired());
 	}
 
-	/**
-	 * @return array
-	 */
 	public function generateReportsWithExpiration(): array {
 	    $request = new Request('POST', 'https://example.com');
 		return [
@@ -36,17 +31,12 @@ class MessageSentReportTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	/**
-	 * @param MessageSentReport $report
-	 * @param string            $expected
 	 * @dataProvider generateReportsWithEndpoints
 	 */
 	public function testGetEndpoint(MessageSentReport $report, string $expected): void {
 		$this->assertEquals($expected, $report->getEndpoint());
 	}
 
-	/**
-	 * @return array
-	 */
 	public function generateReportsWithEndpoints(): array {
 		return [
 			[new MessageSentReport(new Request('POST', 'https://www.example.com')), 'https://www.example.com'],
@@ -56,8 +46,6 @@ class MessageSentReportTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	/**
-	 * @param MessageSentReport $report
-	 * @param Request           $expected
 	 * @dataProvider generateReportsWithRequests
 	 */
 	public function testGetRequest(MessageSentReport $report, Request $expected): void {
@@ -77,12 +65,10 @@ class MessageSentReportTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	/**
-	 * @param MessageSentReport $report
-	 * @param string            $json
 	 * @dataProvider generateReportsWithJson
 	 */
 	public function testJsonSerialize(MessageSentReport $report, string $json): void {
-		$this->assertJsonStringEqualsJsonString($json, json_encode($report));
+		$this->assertJsonStringEqualsJsonString($json, json_encode($report, JSON_THROW_ON_ERROR));
 	}
 
 	public function generateReportsWithJson(): array {
@@ -103,7 +89,7 @@ class MessageSentReportTest extends \PHPUnit\Framework\TestCase {
 					'reason'   => 'OK',
 					'endpoint' => (string) $request1->getUri(),
 					'payload'  => $request1Body,
-				])
+				], JSON_THROW_ON_ERROR)
 			],
 			[
 				new MessageSentReport($request2, $response2, false, 'Gone'),
@@ -113,23 +99,18 @@ class MessageSentReportTest extends \PHPUnit\Framework\TestCase {
 					'reason'   => 'Gone',
 					'endpoint' => (string) $request2->getUri(),
 					'payload'  => $request2Body,
-				])
+				], JSON_THROW_ON_ERROR)
 			]
 		];
 	}
 
 	/**
-	 * @param MessageSentReport $report
-	 * @param bool              $expected
 	 * @dataProvider generateReportsWithSuccess
 	 */
 	public function testIsSuccess(MessageSentReport $report, bool $expected): void {
 		$this->assertEquals($expected, $report->isSuccess());
 	}
 
-	/**
-	 * @return array
-	 */
 	public function generateReportsWithSuccess(): array {
         $request = new Request('POST', 'https://example.com');
 		return [

--- a/tests/PushServiceTest.php
+++ b/tests/PushServiceTest.php
@@ -113,7 +113,7 @@ final class PushServiceTest extends PHPUnit\Framework\TestCase
                 $subscriptionParameters['vapidPublicKey'] = self::$vapidKeys['publicKey'];
             }
 
-            $subscriptionParameters = json_encode($subscriptionParameters);
+            $subscriptionParameters = json_encode($subscriptionParameters, JSON_THROW_ON_ERROR);
 
             $getSubscriptionCurl = curl_init(self::$testServiceUrl.'/api/get-subscription/');
             curl_setopt_array($getSubscriptionCurl, [
@@ -143,7 +143,7 @@ final class PushServiceTest extends PHPUnit\Framework\TestCase
 
             foreach ($supportedContentEncodings as $contentEncoding) {
                 if (!in_array($contentEncoding, ['aesgcm', 'aes128gcm'])) {
-                    $this->expectException('ErrorException');
+                    $this->expectException(\ErrorException::class);
                     $this->expectExceptionMessage('This content encoding ('.$contentEncoding.') is not supported.');
                     $this->markTestIncomplete('Unsupported content encoding: '.$contentEncoding);
                 }
@@ -157,7 +157,7 @@ final class PushServiceTest extends PHPUnit\Framework\TestCase
                 $dataString = json_encode([
                     'testSuiteId' => self::$testSuiteId,
                     'testId' => $testId,
-                ]);
+                ], JSON_THROW_ON_ERROR);
 
                 $getNotificationCurl = curl_init(self::$testServiceUrl.'/api/get-notification-status/');
                 curl_setopt_array($getNotificationCurl, [
@@ -174,11 +174,11 @@ final class PushServiceTest extends PHPUnit\Framework\TestCase
                 $parsedResp = $this->getResponse($getNotificationCurl);
 
                 if (!property_exists($parsedResp->{'data'}, 'messages')) {
-                    throw new Exception('web-push-testing-service error, no messages: '.json_encode($parsedResp));
+                    throw new Exception('web-push-testing-service error, no messages: '.json_encode($parsedResp, JSON_THROW_ON_ERROR));
                 }
 
                 $messages = $parsedResp->{'data'}->{'messages'};
-                $this->assertEquals(1, count($messages));
+                $this->assertEquals(1, is_countable($messages) ? count($messages) : 0);
                 $this->assertEquals($payload, $messages[0]);
             }
         };
@@ -217,7 +217,7 @@ final class PushServiceTest extends PHPUnit\Framework\TestCase
             throw new Exception($error);
         }
 
-        $parsedResp = json_decode($resp);
+        $parsedResp = json_decode($resp, null, 512, JSON_THROW_ON_ERROR);
 
         if (!property_exists($parsedResp, 'data')) {
             throw new Exception('web-push-testing-service error: '.$resp);

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -4,7 +4,6 @@ use Minishlink\WebPush\Subscription;
 
 class SubscriptionTest extends PHPUnit\Framework\TestCase
 {
-
     public function testCreateMinimal()
     {
         $subscriptionArray = array(

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -7,12 +7,10 @@ use PHPUnit\Framework\TestCase;
 
 final class UtilsTest extends TestCase
 {
-
     public function testSerializePublicKey()
     {
         $jwk = JWKFactory::createECKey('P-256');
         $serializedPublicKey = Utils::serializePublicKeyFromJWK($jwk);
         $this->assertEquals(130, Utils::safeStrlen($serializedPublicKey));
     }
-
 }

--- a/tests/VAPIDTest.php
+++ b/tests/VAPIDTest.php
@@ -16,7 +16,7 @@ use Minishlink\WebPush\VAPID;
 
 final class VAPIDTest extends PHPUnit\Framework\TestCase
 {
-    public function vapidProvider()
+    public function vapidProvider() : array
     {
         return [
             [
@@ -48,13 +48,6 @@ final class VAPIDTest extends PHPUnit\Framework\TestCase
     /**
      * @dataProvider vapidProvider
      *
-     * @param string $audience
-     * @param array $vapid
-     * @param string $contentEncoding
-     * @param int $expiration
-     * @param string $expectedAuthorization
-     * @param string $expectedCryptoKey
-     *
      * @throws ErrorException
      */
     public function testGetVapidHeaders(string $audience, array $vapid, string $contentEncoding, int $expiration, string $expectedAuthorization, ?string $expectedCryptoKey)
@@ -82,8 +75,6 @@ final class VAPIDTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param string $auth
-     *
      * @return array|string
      */
     private function explodeAuthorization(string $auth)

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -71,7 +71,6 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array
      * @throws ErrorException
      */
     public function notificationProvider(): array
@@ -126,7 +125,7 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
      */
     public function testSendOneNotificationWithTooBigPayload()
     {
-        $this->expectException('ErrorException');
+        $this->expectException(\ErrorException::class);
         $this->expectExceptionMessage('Size of payload must not be greater than 4078 octets.');
 
         $subscription = new Subscription(self::$endpoints['standard'], self::$keys['standard']);


### PR DESCRIPTION
See #341

This PR: 
* Drops support for PHP 7.2
* Removes some useless docblock annotations (already as native type declarations)
* Adds return type on a public method of a final class
* Adds some small improvements now we can use PHP 7.3 features.

When this merged, I'll work on a PR that bumps the requirements to PHP 7.4.

I used Rector to update this code. This was my config:
```
use Rector\Core\Configuration\Option;
use Rector\Core\ValueObject\PhpVersion;
use Rector\Set\ValueObject\LevelSetList;
use Rector\Set\ValueObject\SetList;
use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;

return static function (ContainerConfigurator $containerConfigurator): void {
    // get parameters
    $parameters = $containerConfigurator->parameters();
    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_73);
    $parameters->set(Option::PATHS, [
        __DIR__ . '/src',
        __DIR__ . '/tests',
    ]);

    $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, getcwd() . '/phpstan.neon');

    $containerConfigurator->import(SetList::DEAD_CODE);
    $containerConfigurator->import(LevelSetList::UP_TO_PHP_73);
};
```