### PR TITLE
chore: allow jwt-framework 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
     "ext-mbstring": "*",
     "ext-openssl": "*",
     "guzzlehttp/guzzle": "^7.0.1|^6.2",
-    "web-token/jwt-signature": "^2.0|^3.0",
-    "web-token/jwt-key-mgmt": "^2.0|^3.0",
-    "web-token/jwt-signature-algorithm-ecdsa": "^2.0|^3.0",
-    "web-token/jwt-util-ecc": "^2.0|^3.0",
+    "web-token/jwt-signature": "^2.0|^3.0.2",
+    "web-token/jwt-key-mgmt": "^2.0|^3.0.2",
+    "web-token/jwt-signature-algorithm-ecdsa": "^2.0|^3.0.2",
+    "web-token/jwt-util-ecc": "^2.0|^3.0.2",
     "spomky-labs/base64url": "^2.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,11 @@
     "ext-mbstring": "*",
     "ext-openssl": "*",
     "guzzlehttp/guzzle": "^7.0.1|^6.2",
-    "web-token/jwt-signature": "^2.0",
-    "web-token/jwt-key-mgmt": "^2.0",
-    "web-token/jwt-signature-algorithm-ecdsa": "^2.0",
-    "web-token/jwt-util-ecc": "^2.0"
+    "web-token/jwt-signature": "^2.0|^3.0",
+    "web-token/jwt-key-mgmt": "^2.0|^3.0",
+    "web-token/jwt-signature-algorithm-ecdsa": "^2.0|^3.0",
+    "web-token/jwt-util-ecc": "^2.0|^3.0",
+    "spomky-labs/base64url": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0|^9.0",


### PR DESCRIPTION
This PR allows jwt-framework v3.0. The main change is that it requires PHP 8.1, so using v2.0 is still allowed. `spomky-labs/base64url` is added as direct dependency, because jwt-framework v3.0 doesn't have this dependency.