### PR TITLE
Drop eol php

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,14 +12,14 @@ helps with diagnosing problems quicker.
 > better.
 
 * *Operating System*: <Linux | Windows | OS X>
-* *PHP Version*: <5.6 | 7.0 | ...>
-* *web-push-php Version*: <1.0.0>
+* *PHP Version*: <8.0 | 8.1 | ...>
+* *web-push-php Version*: <8.0.0>
 
 > Please check that you have installed and enabled these PHP extensions :
 
+- [ ] curl
 - [ ] gmp
 - [ ] mbstring
-- [ ] curl
 - [ ] openssl
 
 > Please select any browsers that you are experiencing problems with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,56 +15,46 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.3', '7.4', '8.0', '8.1']
+        php: ['8.0', '8.1', '8.2']
+        ext: ['curl, mbstring, openssl', 'curl, mbstring, openssl, gmp']
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} (${{ matrix.ext }})
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Setup PHP
+      - name: Setup PHP ${{ matrix.php }} (${{ matrix.ext }})
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: curl, mbstring, openssl, gmp
+          extensions: ${{ matrix.ext }}
           coverage: none
 
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '16'
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: /tmp/composer-cache
-          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
 
-      - name: Prepare composer
+      - name: Install dependencies
+        run: composer install --prefer-dist
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install web-push-testing-service
         run: |
-          EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
-          php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-          ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+          npm install -g web-push-testing
 
-          if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
-          then
-              >&2 echo 'ERROR: Invalid installer checksum'
-              rm composer-setup.php
-              exit 1
-          fi
-
-          sudo php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
-          RESULT=$?
-          rm composer-setup.php
-          composer config discard-changes true
-          composer install
-
-      - name: Setup web-push-testing-service
-        run: |
-          npm install web-push-testing -g
-
-      - name: Run tests
+      - name: Run unit tests
         run: |
           web-push-testing --port 9012 start
           composer test:unit
@@ -74,5 +64,5 @@ jobs:
         run: composer test:typing
 
       - name: Run php-cs-fixer
-        if: ${{ matrix.php != '8.1' }}
+        if: ${{ matrix.php != '8.2' }} # Not supported yet.
         run: composer test:syntax

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ As it is standardized, you don't have to worry about what server type it relies 
 
 ## Requirements
 
-PHP 7.3+ and the following extensions:
+PHP 8.0+ and the following extensions:
  * gmp (optional but better for performance)
  * mbstring
  * curl
@@ -21,6 +21,7 @@ There is no support and maintenance for older PHP versions, however you are free
 - PHP 7.0: `v2.x`
 - PHP 7.1: `v3.x-v5.x`
 - PHP 7.2: `v6.x`
+- PHP 7.3 7.4: `v7.x`
 
 ## Installation
 Use [composer](https://getcomposer.org/) to download and install the library and its dependencies.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "test:syntax": "./vendor/bin/php-cs-fixer fix ./src --dry-run --stop-on-violation --using-cache=no"
   },
   "require": {
-    "php": ">=7.3",
+    "php": ">=8.0",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
@@ -31,9 +31,9 @@
     "spomky-labs/base64url": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.0|^9.0",
-    "phpstan/phpstan": "^0.11|^0.12",
-    "friendsofphp/php-cs-fixer": "^2.14"
+    "phpunit/phpunit": "^9.5.27",
+    "phpstan/phpstan": "^1.9.8",
+    "friendsofphp/php-cs-fixer": "^v3.13.2"
   },
   "autoload": {
     "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
     "web-token/jwt-util-ecc": "^2.0|^3.0.2",
     "spomky-labs/base64url": "^2.0"
   },
+  "suggest": {
+    "ext-gmp": "Optional for performance."
+  },
   "require-dev": {
     "phpunit/phpunit": "^9.5.27",
     "phpstan/phpstan": "^1.9.8",

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -72,18 +72,11 @@ class WebPush
             'mbstring' => '[WebPush] mbstring extension is not loaded but is required for sending push notifications with payload or for VAPID authentication. You can fix this in your php.ini.',
             'openssl' => '[WebPush] openssl extension is not loaded but is required for sending push notifications with payload or for VAPID authentication. You can fix this in your php.ini.',
         ];
-        $phpVersion = phpversion();
-        if ($phpVersion && version_compare($phpVersion, '7.3.0', '<')) {
-            $extensions['gmp'] = '[WebPush] gmp extension is not loaded but is required for sending push notifications with payload or for VAPID authentication. You can fix this in your php.ini.';
-        }
+
         foreach ($extensions as $extension => $message) {
             if (!extension_loaded($extension)) {
                 trigger_error($message, E_USER_WARNING);
             }
-        }
-
-        if (ini_get('mbstring.func_overload') >= 2) {
-            trigger_error("[WebPush] mbstring.func_overload is enabled for str* functions. You must disable it if you want to send push notifications with payload or use VAPID. You can fix this in your php.ini.", E_USER_NOTICE);
         }
 
         if (isset($auth['VAPID'])) {


### PR DESCRIPTION
* Add php 8.2 to Github tests
* Add extension suggestion to composer
* Remove outdated php 7.x code
* Github test with disabled `gmp` extension