### PR TITLE
Grouped dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
   directory: "/"
   schedule:
     interval: "monthly"
+  groups:
+    github-actions:
+      patterns:
+        - "*"


### PR DESCRIPTION
News:
https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/

Result:
Just one PR instead of one PR per updated dependency.