### PR TITLE
chore: drop eol php 8.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,8 @@
 /.gitattributes export-ignore
 /.github export-ignore
 /.gitignore export-ignore
-/.travis.yml export-ignore
-/phpunit.xml.dist export-ignore
+/.php-cs-fixer.php export-ignore
 /README.md export-ignore
+/phpstan.neon export-ignore
+/phpunit.xml.dist export-ignore
 /tests export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php: ['8.1', '8.2', '8.3']
         ext: ['curl, mbstring, openssl', 'curl, mbstring, openssl, gmp']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3']
+        php: ['8.1', '8.2', '8.3']
         ext: ['curl, mbstring, openssl', 'curl, mbstring, openssl, gmp']
 
     name: PHP ${{ matrix.php }} (${{ matrix.ext }})

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -49,9 +49,9 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
-      - name: Install web-push-testing-service
+      - name: Install web-push-testing server
         run: |
           npm install -g web-push-testing
 
@@ -65,7 +65,6 @@ jobs:
         run: composer test:typing
 
       - name: Run php-cs-fixer
-        if: ${{ matrix.php != '8.2' }} # Not supported yet.
         run: |
           composer test:syntax
           composer test:syntax_tests

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@ cli.log
 module.log
 .vagrant
 Vagrantfile # temp, may be?
-/.phpunit.result.cache
+.phpunit.cache/*
 .php-cs-fixer.cache
 .idea/

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,21 @@
+<?php
+// https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/config.rst
+
+$config = new PhpCsFixer\Config();
+$rules  = [
+    '@PSR12'                              => true, // The default rule.
+    '@PHP81Migration'                     => true, // Must be the same as the min PHP version.
+    'blank_line_after_opening_tag'        => false, // Do not waste space between <?php and declare.
+    'global_namespace_import'             => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
+    'php_unit_test_class_requires_covers' => true,
+    'php_unit_method_casing'              => true,
+    // Do not enable by default. These rules require review!! (but they are useful)
+    // '@PHP80Migration:risky'      => true,
+    // '@PHPUnit100Migration:risky' => true,
+];
+
+$config->setRules($rules);
+$config->setHideProgress(true);
+$config->setRiskyAllowed(true);
+
+return $config;

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ As it is standardized, you don't have to worry about what server type it relies 
 
 ## Requirements
 
-PHP 8.0+ and the following extensions:
+PHP 8.1+ and the following extensions:
  * gmp (optional but better for performance)
  * mbstring
  * curl
@@ -21,6 +21,7 @@ There is no support and maintenance for older PHP versions, however you are free
 - PHP 7.1: `v3.x-v5.x`
 - PHP 7.2: `v6.x`
 - PHP 7.3 7.4: `v7.x`
+- PHP 8.0: `v8.x`
 
 This README is only compatible with the latest version. Each version of the library has a git tag where the corresponding README can be read.
 

--- a/composer.json
+++ b/composer.json
@@ -26,20 +26,20 @@
     "ext-json": "*",
     "ext-mbstring": "*",
     "ext-openssl": "*",
-    "guzzlehttp/guzzle": "^7.0.1|^6.2",
-    "web-token/jwt-signature": "^2.0|^3.0.2",
-    "web-token/jwt-key-mgmt": "^2.0|^3.0.2",
-    "web-token/jwt-signature-algorithm-ecdsa": "^2.0|^3.0.2",
-    "web-token/jwt-util-ecc": "^2.0|^3.0.2",
-    "spomky-labs/base64url": "^2.0"
+    "guzzlehttp/guzzle": "^7.4.5",
+    "web-token/jwt-signature": "^3.2.9",
+    "web-token/jwt-key-mgmt": "^3.2.9",
+    "web-token/jwt-signature-algorithm-ecdsa": "^3.2.9",
+    "web-token/jwt-util-ecc": "^3.2.9",
+    "spomky-labs/base64url": "^2.0.4"
   },
   "suggest": {
     "ext-gmp": "Optional for performance."
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5.27",
-    "phpstan/phpstan": "^1.9.8",
-    "friendsofphp/php-cs-fixer": "^v3.13.2"
+    "phpunit/phpunit": "^9.6.16",
+    "phpstan/phpstan": "^1.10.57",
+    "friendsofphp/php-cs-fixer": "^v3.48.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
   "scripts": {
     "fix:syntax": "./vendor/bin/php-cs-fixer fix ./src --using-cache=no",
     "fix:syntax_tests": "./vendor/bin/php-cs-fixer fix ./tests --using-cache=no",
-    "test:unit": "./vendor/bin/phpunit --color",
+    "test:unit": "./vendor/bin/phpunit",
+    "test:unit_offline": "./vendor/bin/phpunit --exclude-group=online",
     "test:typing": "./vendor/bin/phpstan analyse",
     "test:syntax": "./vendor/bin/php-cs-fixer fix ./src --dry-run --stop-on-violation --using-cache=no",
     "test:syntax_tests": "./vendor/bin/php-cs-fixer fix ./tests --dry-run --stop-on-violation --using-cache=no"
@@ -37,7 +38,7 @@
     "ext-gmp": "Optional for performance."
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.6.16",
+    "phpunit/phpunit": "^10.5.9",
     "phpstan/phpstan": "^1.10.57",
     "friendsofphp/php-cs-fixer": "^v3.48.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "test:syntax_tests": "./vendor/bin/php-cs-fixer fix ./tests --dry-run --stop-on-violation --using-cache=no"
   },
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.1",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+         backupStaticProperties="false"
          bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+>
+    <source ignoreSuppressionOfDeprecations="true"
+            ignoreSuppressionOfPhpDeprecations="true"
+            ignoreSuppressionOfErrors="true"
+            ignoreSuppressionOfNotices="true"
+            ignoreSuppressionOfPhpNotices="true"
+            ignoreSuppressionOfWarnings="true"
+            ignoreSuppressionOfPhpWarnings="true"
+    >
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
     <testsuites>
         <testsuite name="WebPush Test Suite">
             <directory suffix=".php">./tests/</directory>

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -255,7 +255,7 @@ class Encryption
                     'x' => Base64Url::encode(self::addNullPadding($publicKey->getPoint()->getX()->toBytes(false))),
                     'y' => Base64Url::encode(self::addNullPadding($publicKey->getPoint()->getY()->toBytes(false))),
                     'd' => Base64Url::encode(self::addNullPadding($privateKey->getSecret()->toBytes(false))),
-                ])
+                ]),
             ];
         }
 
@@ -266,7 +266,7 @@ class Encryption
                 'x' => Base64Url::encode(self::addNullPadding(hex2bin(gmp_strval($publicKey->getPoint()->getX(), 16)))),
                 'y' => Base64Url::encode(self::addNullPadding(hex2bin(gmp_strval($publicKey->getPoint()->getY(), 16)))),
                 'd' => Base64Url::encode(self::addNullPadding(hex2bin(gmp_strval($privateKey->getSecret(), 16)))),
-            ])
+            ]),
         ];
     }
 
@@ -294,7 +294,7 @@ class Encryption
                 'x' => Base64Url::encode(self::addNullPadding($details['ec']['x'])),
                 'y' => Base64Url::encode(self::addNullPadding($details['ec']['y'])),
                 'd' => Base64Url::encode(self::addNullPadding($details['ec']['d'])),
-            ])
+            ]),
         ];
     }
 

--- a/src/VAPID.php
+++ b/src/VAPID.php
@@ -176,7 +176,7 @@ class VAPID
 
         return [
             'publicKey'  => Base64Url::encode($binaryPublicKey),
-            'privateKey' => Base64Url::encode($binaryPrivateKey)
+            'privateKey' => Base64Url::encode($binaryPrivateKey),
         ];
     }
 }

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -1,7 +1,4 @@
-<?php
-
-declare(strict_types=1);
-
+<?php declare(strict_types=1);
 /*
  * This file is part of the WebPush library.
  *
@@ -15,7 +12,11 @@ use Base64Url\Base64Url;
 use Jose\Component\Core\JWK;
 use Minishlink\WebPush\Encryption;
 use Minishlink\WebPush\Utils;
+use PHPUnit\Framework\Attributes\DataProvider;
 
+/**
+ * @covers \Minishlink\WebPush\Encryption
+ */
 final class EncryptionTest extends PHPUnit\Framework\TestCase
 {
     public function testDeterministicEncrypt(): void
@@ -75,10 +76,9 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider payloadProvider
-     *
      * @throws ErrorException
      */
+    #[dataProvider('payloadProvider')]
     public function testPadPayload(string $payload, int $maxLengthToPad, int $expectedResLength): void
     {
         $res = Encryption::padPayload($payload, $maxLengthToPad, "aesgcm");
@@ -87,7 +87,7 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expectedResLength, Utils::safeStrlen($res));
     }
 
-    public function payloadProvider(): array
+    public static function payloadProvider(): array
     {
         return [
             ['testé', 0, 8],

--- a/tests/MessageSentReportTest.php
+++ b/tests/MessageSentReportTest.php
@@ -28,7 +28,7 @@ class MessageSentReportTest extends TestCase
             [new MessageSentReport($request, new Response(404)), true],
             [new MessageSentReport($request, new Response(410)), true],
             [new MessageSentReport($request, new Response(500)), false],
-            [new MessageSentReport($request, new Response(200)), false]
+            [new MessageSentReport($request, new Response(200)), false],
         ];
     }
 
@@ -91,7 +91,7 @@ class MessageSentReportTest extends TestCase
                     'reason'   => 'OK',
                     'endpoint' => (string) $request1->getUri(),
                     'payload'  => $request1Body,
-                ], JSON_THROW_ON_ERROR)
+                ], JSON_THROW_ON_ERROR),
             ],
             [
                 new MessageSentReport($request2, $response2, false, 'Gone'),
@@ -101,8 +101,8 @@ class MessageSentReportTest extends TestCase
                     'reason'   => 'Gone',
                     'endpoint' => (string) $request2->getUri(),
                     'payload'  => $request2Body,
-                ], JSON_THROW_ON_ERROR)
-            ]
+                ], JSON_THROW_ON_ERROR),
+            ],
         ];
     }
 

--- a/tests/MessageSentReportTest.php
+++ b/tests/MessageSentReportTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * @author Igor Timoshenkov [it@campoint.net]
  * @started: 2018-12-03 11:31
@@ -7,6 +7,7 @@
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Minishlink\WebPush\MessageSentReport;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,15 +15,13 @@ use PHPUnit\Framework\TestCase;
  */
 class MessageSentReportTest extends TestCase
 {
-    /**
-     * @dataProvider generateReportsWithExpiration
-     */
+    #[dataProvider('generateReportsWithExpiration')]
     public function testIsSubscriptionExpired(MessageSentReport $report, bool $expected): void
     {
         $this->assertEquals($expected, $report->isSubscriptionExpired());
     }
 
-    public function generateReportsWithExpiration(): array
+    public static function generateReportsWithExpiration(): array
     {
         $request = new Request('POST', 'https://example.com');
         return [
@@ -33,15 +32,13 @@ class MessageSentReportTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider generateReportsWithEndpoints
-     */
+    #[dataProvider('generateReportsWithEndpoints')]
     public function testGetEndpoint(MessageSentReport $report, string $expected): void
     {
         $this->assertEquals($expected, $report->getEndpoint());
     }
 
-    public function generateReportsWithEndpoints(): array
+    public static function generateReportsWithEndpoints(): array
     {
         return [
             [new MessageSentReport(new Request('POST', 'https://www.example.com')), 'https://www.example.com'],
@@ -50,15 +47,13 @@ class MessageSentReportTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider generateReportsWithRequests
-     */
+    #[dataProvider('generateReportsWithRequests')]
     public function testGetRequest(MessageSentReport $report, Request $expected): void
     {
         $this->assertEquals($expected, $report->getRequest());
     }
 
-    public function generateReportsWithRequests(): array
+    public static function generateReportsWithRequests(): array
     {
         $r1 = new Request('POST', 'https://www.example.com');
         $r2 = new Request('PUT', 'https://m.example.com');
@@ -71,15 +66,13 @@ class MessageSentReportTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider generateReportsWithJson
-     */
+    #[dataProvider('generateReportsWithJson')]
     public function testJsonSerialize(MessageSentReport $report, string $json): void
     {
         $this->assertJsonStringEqualsJsonString($json, json_encode($report, JSON_THROW_ON_ERROR));
     }
 
-    public function generateReportsWithJson(): array
+    public static function generateReportsWithJson(): array
     {
         $request1Body = json_encode(['title' => 'test', 'body' => 'blah', 'data' => []], JSON_THROW_ON_ERROR);
         $request1 = new Request('POST', 'https://www.example.com', [], $request1Body);
@@ -113,15 +106,13 @@ class MessageSentReportTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider generateReportsWithSuccess
-     */
+    #[dataProvider('generateReportsWithSuccess')]
     public function testIsSuccess(MessageSentReport $report, bool $expected): void
     {
         $this->assertEquals($expected, $report->isSuccess());
     }
 
-    public function generateReportsWithSuccess(): array
+    public static function generateReportsWithSuccess(): array
     {
         $request = new Request('POST', 'https://example.com');
         return [

--- a/tests/PushServiceTest.php
+++ b/tests/PushServiceTest.php
@@ -1,7 +1,4 @@
-<?php
-
-declare(strict_types=1);
-
+<?php declare(strict_types=1);
 /*
  * This file is part of the WebPush library.
  *
@@ -14,7 +11,14 @@ declare(strict_types=1);
 use Minishlink\WebPush\MessageSentReport;
 use Minishlink\WebPush\Subscription;
 use Minishlink\WebPush\WebPush;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+/**
+ * Test with test server.
+ * @coversNothing
+ */
+#[group('online')]
 final class PushServiceTest extends PHPUnit\Framework\TestCase
 {
     private static int    $timeout    = 30;
@@ -37,7 +41,7 @@ final class PushServiceTest extends PHPUnit\Framework\TestCase
         self::$testServiceUrl = 'http://localhost:'.self::$portNumber;
     }
 
-    public function browserProvider(): array
+    public static function browserProvider(): array
     {
         return [
             ['firefox', ['VAPID' => self::$vapidKeys]],
@@ -68,9 +72,9 @@ final class PushServiceTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider browserProvider
      * Run integration tests with browsers
      */
+    #[dataProvider('browserProvider')]
     public function testBrowsers($browserId, $options): void
     {
         $this->retryTest(2, $this->createClosureTest($browserId, $options));
@@ -78,7 +82,7 @@ final class PushServiceTest extends PHPUnit\Framework\TestCase
 
     protected function createClosureTest($browserId, $options): callable
     {
-        return function () use ($browserId, $options) {
+        return function () use ($browserId, $options): void {
             $this->webPush = new WebPush($options);
             $this->webPush->setAutomaticPadding(false);
             $subscriptionParameters = [];

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -1,7 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 use Minishlink\WebPush\Subscription;
 
+/**
+ * @covers \Minishlink\WebPush\Subscription
+ */
 class SubscriptionTest extends PHPUnit\Framework\TestCase
 {
     public function testCreateMinimal(): void

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -9,9 +9,9 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
 {
     public function testCreateMinimal(): void
     {
-        $subscriptionArray = array(
-            "endpoint" => "http://toto.com"
-        );
+        $subscriptionArray = [
+            "endpoint" => "http://toto.com",
+        ];
         $subscription = Subscription::create($subscriptionArray);
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals(null, $subscription->getPublicKey());
@@ -30,11 +30,11 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
 
     public function testCreatePartial(): void
     {
-        $subscriptionArray = array(
+        $subscriptionArray = [
             "endpoint" => "http://toto.com",
             "publicKey" => "publicKey",
             "authToken" => "authToken",
-        );
+        ];
         $subscription = Subscription::create($subscriptionArray);
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
@@ -53,12 +53,12 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
 
     public function testCreateFull(): void
     {
-        $subscriptionArray = array(
+        $subscriptionArray = [
             "endpoint" => "http://toto.com",
             "publicKey" => "publicKey",
             "authToken" => "authToken",
             "contentEncoding" => "aes128gcm",
-        );
+        ];
         $subscription = Subscription::create($subscriptionArray);
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
@@ -81,8 +81,8 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
             "endpoint" => "http://toto.com",
             "keys" => [
                 'p256dh' => 'publicKey',
-                'auth' => 'authToken'
-            ]
+                'auth' => 'authToken',
+            ],
         ]);
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
@@ -96,8 +96,8 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
             "contentEncoding" => 'aes128gcm',
             "keys" => [
                 'p256dh' => 'publicKey',
-                'auth' => 'authToken'
-            ]
+                'auth' => 'authToken',
+            ],
         ]);
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -1,9 +1,12 @@
-<?php
+<?php declare(strict_types=1);
 
 use Jose\Component\KeyManagement\JWKFactory;
 use Minishlink\WebPush\Utils;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Minishlink\WebPush\Utils
+ */
 final class UtilsTest extends TestCase
 {
     public function testSerializePublicKey(): void

--- a/tests/VAPIDTest.php
+++ b/tests/VAPIDTest.php
@@ -1,7 +1,4 @@
-<?php
-
-declare(strict_types=1);
-
+<?php declare(strict_types=1);
 /*
  * This file is part of the WebPush library.
  *
@@ -13,10 +10,14 @@ declare(strict_types=1);
 
 use Minishlink\WebPush\Utils;
 use Minishlink\WebPush\VAPID;
+use PHPUnit\Framework\Attributes\DataProvider;
 
+/**
+ * @covers \Minishlink\WebPush\VAPID
+ */
 final class VAPIDTest extends PHPUnit\Framework\TestCase
 {
-    public function vapidProvider(): array
+    public static function vapidProvider(): array
     {
         return [
             [
@@ -46,10 +47,9 @@ final class VAPIDTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider vapidProvider
-     *
      * @throws ErrorException
      */
+    #[dataProvider('vapidProvider')]
     public function testGetVapidHeaders(string $audience, array $vapid, string $contentEncoding, int $expiration, string $expectedAuthorization, ?string $expectedCryptoKey): void
     {
         $vapid = VAPID::validate($vapid);

--- a/tests/WebPushTest.php
+++ b/tests/WebPushTest.php
@@ -1,7 +1,4 @@
-<?php
-
-declare(strict_types=1);
-
+<?php declare(strict_types=1);
 /*
  * This file is part of the WebPush library.
  *
@@ -14,7 +11,11 @@ declare(strict_types=1);
 use Minishlink\WebPush\Subscription;
 use Minishlink\WebPush\SubscriptionInterface;
 use Minishlink\WebPush\WebPush;
+use PHPUnit\Framework\Attributes\DataProvider;
 
+/**
+ * @covers \Minishlink\WebPush\WebPush
+ */
 final class WebPushTest extends PHPUnit\Framework\TestCase
 {
     private static array $endpoints;
@@ -124,7 +125,7 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
     /**
      * @throws ErrorException
      */
-    public function notificationProvider(): array
+    public static function notificationProvider(): array
     {
         self::setUpBeforeClass(); // dirty hack of PHPUnit limitation
 
@@ -134,12 +135,11 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider notificationProvider
-     *
      * @param SubscriptionInterface $subscription
      * @param string                $payload
      * @throws ErrorException
      */
+    #[dataProvider('notificationProvider')]
     public function testSendOneNotification(SubscriptionInterface $subscription, string $payload): void
     {
         $report = $this->webPush->sendOneNotification($subscription, $payload);
@@ -154,7 +154,7 @@ final class WebPushTest extends PHPUnit\Framework\TestCase
         $batchSize = 10;
         $total = 50;
 
-        $notifications = $this->notificationProvider();
+        $notifications = self::notificationProvider();
         $notifications = array_fill(0, $total, $notifications[0]);
 
         foreach ($notifications as $notification) {


### PR DESCRIPTION
BREAKING changes:

* chore: drop eol php 8.0
* chore: drop outdated dependencies
  * web-token/*: ^2
  * guzzlehttp/guzzle: ^6

Other changes:

* chore: migrate to phpunit 10
* fix: remove outdated polyfill for php before 7.3