### PR TITLE
fix(ci): disable default extensions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,20 +17,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3']
-        ext: ['curl, mbstring, openssl', 'curl, mbstring, openssl, gmp']
+        php: [ '8.1', '8.2', '8.3' ]
+        ext_base: [ 'none, dom, tokenizer, xml, xmlwriter,' ]
+        ext_lib: [ 'curl, mbstring, openssl,' ]
+        ext_optional: [ '', 'bcmath', 'gmp' ]
 
-    name: PHP ${{ matrix.php }} (${{ matrix.ext }})
+    name: PHP ${{ matrix.php }} (${{ matrix.ext_optional }})
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup PHP ${{ matrix.php }} (${{ matrix.ext }})
+      - name: Setup PHP ${{ matrix.php }} (${{ matrix.ext_optional }})
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: ${{ matrix.ext }}
+          extensions:  ${{ matrix.ext_base }}${{ matrix.ext_lib }}${{ matrix.ext_optional }}
           coverage: none
 
       - name: Get composer cache directory


### PR DESCRIPTION
## Problem

By default GH Action shivammathur/setup-php@v2 does enable several extensions. The goal to test against missing `gmp` does not work because it was enabled by default.
Now disable all extensions and just enable the required.

## Change

* disable default extensions
* test against an additional extension