### PR TITLE
feat: check for openssl with all required functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ As it is standardized, you don't have to worry about what server type it relies 
 ## Requirements
 
 PHP 8.1+ and the following extensions:
- * gmp (optional but better for performance)
+ * bcmath and/or gmp (optional but better for performance)
  * mbstring
  * curl
- * openssl
+ * openssl (with elliptic curve support)
 
 There is no support and maintenance for older PHP versions, however you are free to use the following compatible versions:
 - PHP 5.6 or HHVM: `v1.x`

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "spomky-labs/base64url": "^2.0.4"
   },
   "suggest": {
+    "ext-bcmath": "Optional for performance.",
     "ext-gmp": "Optional for performance."
   },
   "require-dev": {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -63,4 +63,74 @@ class Utils
             hex2bin(mb_substr($data, $dataLength / 2, null, '8bit')),
         ];
     }
+
+    /**
+     * Generates user warning/notice if some requirements are not met.
+     * Does not throw exception to allow unusual or polyfill environments.
+     */
+    public static function checkRequirement(): void
+    {
+        self::checkRequirementExtension();
+        self::checkRequirementKeyCipherHash();
+    }
+
+    public static function checkRequirementExtension(): void
+    {
+        $requiredExtensions = [
+            'curl'     => '[WebPush] curl extension is not loaded but is required. You can fix this in your php.ini.',
+            'mbstring' => '[WebPush] mbstring extension is not loaded but is required for sending push notifications with payload or for VAPID authentication. You can fix this in your php.ini.',
+            'openssl'  => '[WebPush] openssl extension is not loaded but is required for sending push notifications with payload or for VAPID authentication. You can fix this in your php.ini.',
+        ];
+        foreach($requiredExtensions as $extension => $message) {
+            if(!extension_loaded($extension)) {
+                trigger_error($message, E_USER_WARNING);
+            }
+        }
+
+        // Check optional extensions.
+        if(!extension_loaded("bcmath") && !extension_loaded("gmp")) {
+            trigger_error("It is highly recommended to install the GMP or BCMath extension to speed up calculations. The fastest available calculator implementation will be automatically selected at runtime.", E_USER_NOTICE);
+        }
+    }
+
+    public static function checkRequirementKeyCipherHash(): void
+    {
+        // Print your current openssl version with: OPENSSL_VERSION_TEXT
+        // Check for outdated openssl without EC support.
+        $requiredCurves  = [
+            'prime256v1' => '[WebPush] Openssl does not support required curve prime256v1.',
+        ];
+        $availableCurves = openssl_get_curve_names();
+        if($availableCurves === false) {
+            trigger_error('[WebPush] Openssl does not support curves.', E_USER_WARNING);
+        } else {
+            foreach($requiredCurves as $curve => $message) {
+                if(!in_array($curve, $availableCurves, true)) {
+                    trigger_error($message, E_USER_WARNING);
+                }
+            }
+        }
+
+        // Check for unusual openssl without cipher support.
+        $requiredCiphers  = [
+            'aes-128-gcm' => '[WebPush] Openssl does not support required cipher aes-128-gcm.',
+        ];
+        $availableCiphers = openssl_get_cipher_methods();
+        foreach($requiredCiphers as $cipher => $message) {
+            if(!in_array($cipher, $availableCiphers, true)) {
+                trigger_error($message, E_USER_WARNING);
+            }
+        }
+
+        // Check for unusual php without hash algo support.
+        $requiredHash  = [
+            'sha256' => '[WebPush] Php does not support required hmac hash sha256.',
+        ];
+        $availableHash = hash_hmac_algos();
+        foreach($requiredHash as $hash => $message) {
+            if(!in_array($hash, $availableHash, true)) {
+                trigger_error($message, E_USER_WARNING);
+            }
+        }
+    }
 }

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -60,17 +60,7 @@ class WebPush
      */
     public function __construct(array $auth = [], array $defaultOptions = [], ?int $timeout = 30, array $clientOptions = [])
     {
-        $extensions = [
-            'curl' => '[WebPush] curl extension is not loaded but is required. You can fix this in your php.ini.',
-            'mbstring' => '[WebPush] mbstring extension is not loaded but is required for sending push notifications with payload or for VAPID authentication. You can fix this in your php.ini.',
-            'openssl' => '[WebPush] openssl extension is not loaded but is required for sending push notifications with payload or for VAPID authentication. You can fix this in your php.ini.',
-        ];
-
-        foreach ($extensions as $extension => $message) {
-            if (!extension_loaded($extension)) {
-                trigger_error($message, E_USER_WARNING);
-            }
-        }
+        Utils::checkRequirement();
 
         if (isset($auth['VAPID'])) {
             $auth['VAPID'] = VAPID::validate($auth['VAPID']);


### PR DESCRIPTION
## Background

`web-token/jwt*` uses `brick/math` which does the math.
The performance of calculations can be improved by extension `gmp` and/or `bcmath`.

## Changes

* Add `bcmath` to check/composer (CI test already updated)
* Check for EC curve support by openssl
* Check cipher and hash support