### PR TITLE
chore: [BREAKING] remove old pure php elliptic curve implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ There is no support and maintenance for older PHP versions, however you are free
 - PHP 7.1: `v3.x-v5.x`
 - PHP 7.2: `v6.x`
 - PHP 7.3 7.4: `v7.x`
-- PHP 8.0: `v8.x`
+- PHP 8.0 / Openssl without elliptic curve support: `v8.x`
 
 This README is only compatible with the latest version. Each version of the library has a git tag where the corresponding README can be read.
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Minishlink\WebPush;
 
 use Base64Url\Base64Url;
-use Brick\Math\BigInteger;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\Util\Ecc\PublicKey;
 
@@ -29,13 +28,8 @@ class Utils
     {
         $hexString = '04';
         $point = $publicKey->getPoint();
-        if ($point->getX() instanceof BigInteger) {
-            $hexString .= str_pad($point->getX()->toBase(16), 64, '0', STR_PAD_LEFT);
-            $hexString .= str_pad($point->getY()->toBase(16), 64, '0', STR_PAD_LEFT);
-        } else { // @phpstan-ignore-line
-            $hexString .= str_pad(gmp_strval($point->getX(), 16), 64, '0', STR_PAD_LEFT);
-            $hexString .= str_pad(gmp_strval($point->getY(), 16), 64, '0', STR_PAD_LEFT); // @phpstan-ignore-line
-        }
+        $hexString .= str_pad($point->getX()->toBase(16), 64, '0', STR_PAD_LEFT);
+        $hexString .= str_pad($point->getY()->toBase(16), 64, '0', STR_PAD_LEFT);
 
         return $hexString;
     }


### PR DESCRIPTION
Now requires openssl with elliptic curve support. This is the usual case.