### PR TITLE
fix: [BREAKING]  remove legacy subscription; change subscription interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ A complete example with html+JS frontend and php backend using `web-push-php` ca
 
 ```php
 <?php
-
 use Minishlink\WebPush\WebPush;
 use Minishlink\WebPush\Subscription;
 
@@ -59,36 +58,22 @@ $notifications = [
         'subscription' => $subscription,
         'payload' => '{"message":"Hello World!"}',
     ], [
-          // current PushSubscription format (browsers might change this in the future)
-          'subscription' => Subscription::create([ 
-              "endpoint" => "https://example.com/other/endpoint/of/another/vendor/abcdef...",
-              "keys" => [
-                  'p256dh' => '(stringOf88Chars)',
-                  'auth' => '(stringOf24Chars)'
-              ],
-          ]),
-          'payload' => '{"message":"Hello World!"}',
-    ], [
-        // old Firefox PushSubscription format
-        'subscription' => Subscription::create([
-            'endpoint' => 'https://updates.push.services.mozilla.com/push/abc...', // Firefox 43+,
-            'publicKey' => 'BPcMbnWQL5GOYX/5LKZXT6sLmHiMsJSiEvIFvfcDvX7IZ9qqtq68onpTPEYmyxSQNiH7UD/98AUcQ12kBoxz/0s=', // base 64 encoded, should be 88 chars
-            'authToken' => 'CxVX6QsVToEGEcjfYPqXQw==', // base 64 encoded, should be 24 chars
+        // current PushSubscription format (browsers might change this in the future)
+        'subscription' => Subscription::create([ 
+            'endpoint' => 'https://example.com/other/endpoint/of/another/vendor/abcdef...',
+            'keys' => [
+                'p256dh' => '(stringOf88Chars)',
+                'auth' => '(stringOf24Chars)',
+            ],
         ]),
-        'payload' => 'hello !',
-    ], [
-        // old Chrome PushSubscription format
-        'subscription' => Subscription::create([
-            'endpoint' => 'https://fcm.googleapis.com/fcm/send/abcdef...',
-        ]),
-        'payload' => null,
+        'payload' => '{"message":"Hello World!"}',
     ], [
         // old PushSubscription format
         'subscription' => Subscription::create([
             'endpoint' => 'https://example.com/other/endpoint/of/another/vendor/abcdef...',
             'publicKey' => '(stringOf88Chars)',
             'authToken' => '(stringOf24Chars)',
-            'contentEncoding' => 'aesgcm', // one of PushManager.supportedContentEncodings
+            'contentEncoding' => 'aesgcm', // (optional) one of PushManager.supportedContentEncodings
         ]),
         'payload' => '{"message":"test"}',
     ]
@@ -100,7 +85,7 @@ $webPush = new WebPush();
 foreach ($notifications as $notification) {
     $webPush->queueNotification(
         $notification['subscription'],
-        $notification['payload'] // optional (defaults null)
+        $notification['payload'], // optional (defaults null)
     );
 }
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ A complete example with html+JS frontend and php backend using `web-push-php` ca
 use Minishlink\WebPush\WebPush;
 use Minishlink\WebPush\Subscription;
 
-// store the client-side `PushSubscription` object (calling `.toJSON` on it) as-is and then create a WebPush\Subscription from it
+// Store the client-side `PushSubscription` object (calling `.toJSON` on it) as-is and then create a WebPush\Subscription from it.
 $subscription = Subscription::create(json_decode($clientSidePushSubscriptionJSON, true));
 
-// array of notifications
+// Array of push messages.
 $notifications = [
     [
         'subscription' => $subscription,
@@ -65,6 +65,7 @@ $notifications = [
                 'p256dh' => '(stringOf88Chars)',
                 'auth' => '(stringOf24Chars)',
             ],
+            // key 'contentEncoding' is optional and defaults to ContentEncoding::aes128gcm
         ]),
         'payload' => '{"message":"Hello World!"}',
     ], [
@@ -81,7 +82,7 @@ $notifications = [
 
 $webPush = new WebPush();
 
-// send multiple notifications with payload
+// Send multiple push messages with payload.
 foreach ($notifications as $notification) {
     $webPush->queueNotification(
         $notification['subscription'],
@@ -90,7 +91,7 @@ foreach ($notifications as $notification) {
 }
 
 /**
- * Check sent results
+ * Check sent results.
  * @var MessageSentReport $report
  */
 foreach ($webPush->flush() as $report) {
@@ -104,7 +105,7 @@ foreach ($webPush->flush() as $report) {
 }
 
 /**
- * send one notification and flush directly
+ * Send one push message and flush directly.
  * @var MessageSentReport $report
  */
 $report = $webPush->sendOneNotification(

--- a/src/ContentEncoding.php
+++ b/src/ContentEncoding.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Minishlink\WebPush;
+
+enum ContentEncoding: string
+{
+    /** Outdated historic encoding. Was used by some browsers before rfc standard. Not recommended. */
+    case aesgcm = "aesgcm";
+    /** Defined in rfc8291. */
+    case aes128gcm = "aes128gcm";
+}

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -27,19 +27,19 @@ class Encryption
      * @return string padded payload (plaintext)
      * @throws \ErrorException
      */
-    public static function padPayload(string $payload, int $maxLengthToPad, string $contentEncoding): string
+    public static function padPayload(string $payload, int $maxLengthToPad, ContentEncoding $contentEncoding): string
     {
         $payloadLen = Utils::safeStrlen($payload);
         $padLen = $maxLengthToPad ? $maxLengthToPad - $payloadLen : 0;
 
-        if ($contentEncoding === "aesgcm") {
+        if ($contentEncoding === ContentEncoding::aesgcm) {
             return pack('n*', $padLen).str_pad($payload, $padLen + $payloadLen, chr(0), STR_PAD_LEFT);
         }
-        if ($contentEncoding === "aes128gcm") {
+        if ($contentEncoding === ContentEncoding::aes128gcm) {
             return str_pad($payload.chr(2), $padLen + $payloadLen, chr(0), STR_PAD_RIGHT);
         }
 
-        throw new \ErrorException("This content encoding is not supported: ".$contentEncoding);
+        throw new \ErrorException("This content encoding is not implemented.");
     }
 
     /**
@@ -49,7 +49,7 @@ class Encryption
      *
      * @throws \ErrorException
      */
-    public static function encrypt(string $payload, string $userPublicKey, string $userAuthToken, string $contentEncoding): array
+    public static function encrypt(string $payload, string $userPublicKey, string $userAuthToken, ContentEncoding $contentEncoding): array
     {
         return self::deterministicEncrypt(
             $payload,
@@ -64,8 +64,14 @@ class Encryption
     /**
      * @throws \RuntimeException
      */
-    public static function deterministicEncrypt(string $payload, string $userPublicKey, string $userAuthToken, string $contentEncoding, array $localKeyObject, string $salt): array
-    {
+    public static function deterministicEncrypt(
+        string $payload,
+        string $userPublicKey,
+        string $userAuthToken,
+        ContentEncoding $contentEncoding,
+        array $localKeyObject,
+        string $salt
+    ): array {
         $userPublicKey = Base64UrlSafe::decodeNoPadding($userPublicKey);
         $userAuthToken = Base64UrlSafe::decodeNoPadding($userAuthToken);
 
@@ -112,7 +118,7 @@ class Encryption
         $context = self::createContext($userPublicKey, $localPublicKey, $contentEncoding);
 
         // derive the Content Encryption Key
-        $contentEncryptionKeyInfo = self::createInfo($contentEncoding, $context, $contentEncoding);
+        $contentEncryptionKeyInfo = self::createInfo($contentEncoding->value, $context, $contentEncoding);
         $contentEncryptionKey = self::hkdf($salt, $ikm, $contentEncryptionKeyInfo, 16);
 
         // section 3.3, derive the nonce
@@ -132,16 +138,19 @@ class Encryption
         ];
     }
 
-    public static function getContentCodingHeader(string $salt, string $localPublicKey, string $contentEncoding): string
+    public static function getContentCodingHeader(string $salt, string $localPublicKey, ContentEncoding $contentEncoding): string
     {
-        if ($contentEncoding === "aes128gcm") {
+        if ($contentEncoding === ContentEncoding::aesgcm) {
+            return "";
+        }
+        if ($contentEncoding === ContentEncoding::aes128gcm) {
             return $salt
                 .pack('N*', 4096)
                 .pack('C*', Utils::safeStrlen($localPublicKey))
                 .$localPublicKey;
         }
 
-        return "";
+        throw new \ValueError("This content encoding is not implemented.");
     }
 
     /**
@@ -182,19 +191,19 @@ class Encryption
      *
      * @throws \ErrorException
      */
-    private static function createContext(string $clientPublicKey, string $serverPublicKey, string $contentEncoding): ?string
+    private static function createContext(string $clientPublicKey, string $serverPublicKey, ContentEncoding $contentEncoding): ?string
     {
-        if ($contentEncoding === "aes128gcm") {
+        if ($contentEncoding === ContentEncoding::aes128gcm) {
             return null;
         }
 
         if (Utils::safeStrlen($clientPublicKey) !== 65) {
-            throw new \ErrorException('Invalid client public key length');
+            throw new \ErrorException('Invalid client public key length.');
         }
 
         // This one should never happen, because it's our code that generates the key
         if (Utils::safeStrlen($serverPublicKey) !== 65) {
-            throw new \ErrorException('Invalid server public key length');
+            throw new \ErrorException('Invalid server public key length.');
         }
 
         $len = chr(0).'A'; // 65 as Uint16BE
@@ -212,25 +221,25 @@ class Encryption
      *
      * @throws \ErrorException
      */
-    private static function createInfo(string $type, ?string $context, string $contentEncoding): string
+    private static function createInfo(string $type, ?string $context, ContentEncoding $contentEncoding): string
     {
-        if ($contentEncoding === "aesgcm") {
+        if ($contentEncoding === ContentEncoding::aesgcm) {
             if (!$context) {
-                throw new \ErrorException('Context must exist');
+                throw new \ValueError('Context must exist.');
             }
 
             if (Utils::safeStrlen($context) !== 135) {
-                throw new \ErrorException('Context argument has invalid size');
+                throw new \ValueError('Context argument has invalid size.');
             }
 
             return 'Content-Encoding: '.$type.chr(0).'P-256'.$context;
         }
 
-        if ($contentEncoding === "aes128gcm") {
+        if ($contentEncoding === ContentEncoding::aes128gcm) {
             return 'Content-Encoding: '.$type.chr(0);
         }
 
-        throw new \ErrorException('This content encoding is not supported.');
+        throw new \ErrorException('This content encoding is not implemented.');
     }
 
     private static function createLocalKeyObject(): array
@@ -262,17 +271,18 @@ class Encryption
     /**
      * @throws \ValueError
      */
-    private static function getIKM(string $userAuthToken, string $userPublicKey, string $localPublicKey, string $sharedSecret, string $contentEncoding): string
+    private static function getIKM(string $userAuthToken, string $userPublicKey, string $localPublicKey, string $sharedSecret, ContentEncoding $contentEncoding): string
     {
         if (empty($userAuthToken)) {
             return $sharedSecret;
         }
-        if($contentEncoding === "aesgcm") {
+
+        if ($contentEncoding === ContentEncoding::aesgcm) {
             $info = 'Content-Encoding: auth'.chr(0);
-        } elseif($contentEncoding === "aes128gcm") {
+        } elseif ($contentEncoding === ContentEncoding::aes128gcm) {
             $info = "WebPush: info".chr(0).$userPublicKey.$localPublicKey;
         } else {
-            throw new \ValueError("This content encoding is not supported.");
+            throw new \ValueError("This content encoding is not implemented.");
         }
 
         return self::hkdf($userAuthToken, $sharedSecret, $info, 32);

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -39,7 +39,7 @@ class Encryption
             return str_pad($payload.chr(2), $padLen + $payloadLen, chr(0), STR_PAD_RIGHT);
         }
 
-        throw new \ErrorException("This content encoding is not supported");
+        throw new \ErrorException("This content encoding is not supported: ".$contentEncoding);
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -16,21 +16,21 @@ namespace Minishlink\WebPush;
 class Subscription implements SubscriptionInterface
 {
     /**
-     * @param string|null $contentEncoding (Optional) Must be "aesgcm"
+     * @param string $contentEncoding (Optional) defaults to "aesgcm"
      * @throws \ErrorException
      */
     public function __construct(
-        private string  $endpoint,
-        private ?string $publicKey = null,
-        private ?string $authToken = null,
-        private ?string $contentEncoding = null
+        private readonly string $endpoint,
+        private readonly string $publicKey,
+        private readonly string $authToken,
+        private readonly string $contentEncoding = "aesgcm",
     ) {
-        if($publicKey || $authToken || $contentEncoding) {
-            $supportedContentEncodings = ['aesgcm', 'aes128gcm'];
-            if ($contentEncoding && !in_array($contentEncoding, $supportedContentEncodings, true)) {
-                throw new \ErrorException('This content encoding ('.$contentEncoding.') is not supported.');
-            }
-            $this->contentEncoding = $contentEncoding ?: "aesgcm";
+        $supportedContentEncodings = ['aesgcm', 'aes128gcm'];
+        if ($contentEncoding && !in_array($contentEncoding, $supportedContentEncodings, true)) {
+            throw new \ErrorException('This content encoding ('.$contentEncoding.') is not supported.');
+        }
+        if(empty($publicKey) || empty($authToken) || empty($contentEncoding)) {
+            throw new \ValueError('Missing values.');
         }
     }
 
@@ -42,55 +42,41 @@ class Subscription implements SubscriptionInterface
     {
         if (array_key_exists('keys', $associativeArray) && is_array($associativeArray['keys'])) {
             return new self(
-                $associativeArray['endpoint'],
-                $associativeArray['keys']['p256dh'] ?? null,
-                $associativeArray['keys']['auth'] ?? null,
+                $associativeArray['endpoint'] ?? "",
+                $associativeArray['keys']['p256dh'] ?? "",
+                $associativeArray['keys']['auth'] ?? "",
                 $associativeArray['contentEncoding'] ?? "aesgcm"
             );
         }
 
         if (array_key_exists('publicKey', $associativeArray) || array_key_exists('authToken', $associativeArray) || array_key_exists('contentEncoding', $associativeArray)) {
             return new self(
-                $associativeArray['endpoint'],
-                $associativeArray['publicKey'] ?? null,
-                $associativeArray['authToken'] ?? null,
+                $associativeArray['endpoint'] ?? "",
+                $associativeArray['publicKey'] ?? "",
+                $associativeArray['authToken'] ?? "",
                 $associativeArray['contentEncoding'] ?? "aesgcm"
             );
         }
 
-        return new self(
-            $associativeArray['endpoint']
-        );
+        throw new \ValueError('Missing values.');
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getEndpoint(): string
     {
         return $this->endpoint;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getPublicKey(): ?string
+    public function getPublicKey(): string
     {
         return $this->publicKey;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getAuthToken(): ?string
+    public function getAuthToken(): string
     {
         return $this->authToken;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getContentEncoding(): ?string
+    public function getContentEncoding(): string
     {
         return $this->contentEncoding;
     }

--- a/src/SubscriptionInterface.php
+++ b/src/SubscriptionInterface.php
@@ -25,5 +25,5 @@ interface SubscriptionInterface
 
     public function getAuthToken(): string;
 
-    public function getContentEncoding(): string;
+    public function getContentEncoding(): ContentEncoding;
 }

--- a/src/SubscriptionInterface.php
+++ b/src/SubscriptionInterface.php
@@ -14,15 +14,16 @@ declare(strict_types=1);
 namespace Minishlink\WebPush;
 
 /**
+ * Subscription details from user agent.
  * @author Sergii Bondarenko <sb@firstvector.org>
  */
 interface SubscriptionInterface
 {
     public function getEndpoint(): string;
 
-    public function getPublicKey(): ?string;
+    public function getPublicKey(): string;
 
-    public function getAuthToken(): ?string;
+    public function getAuthToken(): string;
 
-    public function getContentEncoding(): ?string;
+    public function getContentEncoding(): string;
 }

--- a/src/VAPID.php
+++ b/src/VAPID.php
@@ -97,7 +97,7 @@ class VAPID
      * @return array Returns an array with the 'Authorization' and 'Crypto-Key' values to be used as headers
      * @throws \ErrorException
      */
-    public static function getVapidHeaders(string $audience, string $subject, string $publicKey, string $privateKey, string $contentEncoding, ?int $expiration = null): array
+    public static function getVapidHeaders(string $audience, string $subject, string $publicKey, string $privateKey, ContentEncoding $contentEncoding, ?int $expiration = null): array
     {
         $expirationLimit = time() + 43200; // equal margin of error between 0 and 24h
         if (null === $expiration || $expiration > $expirationLimit) {
@@ -138,14 +138,14 @@ class VAPID
         $jwt = $jwsCompactSerializer->serialize($jws, 0);
         $encodedPublicKey = Base64UrlSafe::encodeUnpadded($publicKey);
 
-        if ($contentEncoding === "aesgcm") {
+        if ($contentEncoding === ContentEncoding::aesgcm) {
             return [
                 'Authorization' => 'WebPush '.$jwt,
                 'Crypto-Key' => 'p256ecdsa='.$encodedPublicKey,
             ];
         }
 
-        if ($contentEncoding === 'aes128gcm') {
+        if ($contentEncoding === ContentEncoding::aes128gcm) {
             return [
                 'Authorization' => 'vapid t='.$jwt.', k='.$encodedPublicKey,
             ];

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -9,6 +9,7 @@
  */
 
 use Jose\Component\Core\JWK;
+use Minishlink\WebPush\ContentEncoding;
 use Minishlink\WebPush\Encryption;
 use Minishlink\WebPush\Utils;
 use ParagonIE\ConstantTime\Base64UrlSafe;
@@ -21,7 +22,7 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
 {
     public function testDeterministicEncrypt(): void
     {
-        $contentEncoding = "aes128gcm";
+        $contentEncoding = ContentEncoding::aes128gcm;
         $plaintext = 'When I grow up, I want to be a watermelon';
         $this->assertEquals('V2hlbiBJIGdyb3cgdXAsIEkgd2FudCB0byBiZSBhIHdhdGVybWVsb24', Base64UrlSafe::encodeUnpadded($plaintext));
 
@@ -68,7 +69,7 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
         $localPublicKey = Base64UrlSafe::decodeNoPadding('BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8');
         $salt = Base64UrlSafe::decodeNoPadding('DGv6ra1nlYgDCS1FRnbzlw');
 
-        $result = Encryption::getContentCodingHeader($salt, $localPublicKey, "aes128gcm");
+        $result = Encryption::getContentCodingHeader($salt, $localPublicKey, ContentEncoding::aes128gcm);
         $expected = Base64UrlSafe::decodeNoPadding('DGv6ra1nlYgDCS1FRnbzlwAAEABBBP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8');
 
         $this->assertEquals(Utils::safeStrlen($expected), Utils::safeStrlen($result));
@@ -81,7 +82,7 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
     #[dataProvider('payloadProvider')]
     public function testPadPayload(string $payload, int $maxLengthToPad, int $expectedResLength): void
     {
-        $res = Encryption::padPayload($payload, $maxLengthToPad, "aesgcm");
+        $res = Encryption::padPayload($payload, $maxLengthToPad, ContentEncoding::aesgcm);
 
         $this->assertStringContainsString('test', $res);
         $this->assertEquals($expectedResLength, Utils::safeStrlen($res));

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -7,25 +7,50 @@ use Minishlink\WebPush\Subscription;
  */
 class SubscriptionTest extends PHPUnit\Framework\TestCase
 {
+    /**
+     * Throw exception on outdated call.
+     */
     public function testCreateMinimal(): void
     {
+        $this->expectException(ValueError::class);
         $subscriptionArray = [
             "endpoint" => "http://toto.com",
         ];
-        $subscription = Subscription::create($subscriptionArray);
-        $this->assertEquals("http://toto.com", $subscription->getEndpoint());
-        $this->assertEquals(null, $subscription->getPublicKey());
-        $this->assertEquals(null, $subscription->getAuthToken());
-        $this->assertEquals(null, $subscription->getContentEncoding());
+        Subscription::create($subscriptionArray);
     }
 
+    /**
+     * Throw exception on outdated call.
+     */
     public function testConstructMinimal(): void
     {
-        $subscription = new Subscription("http://toto.com");
-        $this->assertEquals("http://toto.com", $subscription->getEndpoint());
-        $this->assertEquals(null, $subscription->getPublicKey());
-        $this->assertEquals(null, $subscription->getAuthToken());
-        $this->assertEquals(null, $subscription->getContentEncoding());
+        $this->expectException(ArgumentCountError::class);
+        new Subscription("http://toto.com");
+    }
+    public function testExceptionEmpty(): void
+    {
+        $this->expectException(ValueError::class);
+        new Subscription("", "", "");
+    }
+    public function testExceptionEmptyKey(): void
+    {
+        $this->expectException(ValueError::class);
+        $subscriptionArray = [
+            "endpoint" => "http://toto.com",
+            "publicKey" => "",
+            "authToken" => "authToken",
+        ];
+        Subscription::create($subscriptionArray);
+    }
+    public function testExceptionEmptyToken(): void
+    {
+        $this->expectException(ValueError::class);
+        $subscriptionArray = [
+            "endpoint" => "http://toto.com",
+            "publicKey" => "publicKey",
+            "authToken" => "",
+        ];
+        Subscription::create($subscriptionArray);
     }
 
     public function testCreatePartial(): void

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use Minishlink\WebPush\ContentEncoding;
 use Minishlink\WebPush\Subscription;
 
 /**
@@ -64,7 +65,7 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
-        $this->assertEquals("aesgcm", $subscription->getContentEncoding());
+        $this->assertEquals(ContentEncoding::aes128gcm, $subscription->getContentEncoding());
     }
 
     public function testConstructPartial(): void
@@ -73,11 +74,24 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
-        $this->assertEquals("aesgcm", $subscription->getContentEncoding());
+        $this->assertEquals(ContentEncoding::aes128gcm, $subscription->getContentEncoding());
     }
 
     public function testCreateFull(): void
     {
+        $subscriptionArray = [
+            "endpoint" => "http://toto.com",
+            "publicKey" => "publicKey",
+            "authToken" => "authToken",
+            "contentEncoding" => ContentEncoding::aes128gcm,
+        ];
+        $subscription = Subscription::create($subscriptionArray);
+        $this->assertEquals("http://toto.com", $subscription->getEndpoint());
+        $this->assertEquals("publicKey", $subscription->getPublicKey());
+        $this->assertEquals("authToken", $subscription->getAuthToken());
+        $this->assertEquals(ContentEncoding::aes128gcm, $subscription->getContentEncoding());
+
+        // Test with type string contentEncoding
         $subscriptionArray = [
             "endpoint" => "http://toto.com",
             "publicKey" => "publicKey",
@@ -88,18 +102,24 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
-        $this->assertEquals("aes128gcm", $subscription->getContentEncoding());
+        $this->assertEquals(ContentEncoding::aes128gcm, $subscription->getContentEncoding());
     }
 
     public function testConstructFull(): void
     {
-        $subscription = new Subscription("http://toto.com", "publicKey", "authToken", "aes128gcm");
+        $subscription = new Subscription("http://toto.com", "publicKey", "authToken", ContentEncoding::aes128gcm);
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
-        $this->assertEquals("aes128gcm", $subscription->getContentEncoding());
-    }
+        $this->assertEquals(ContentEncoding::aes128gcm, $subscription->getContentEncoding());
 
+        // Test with type string contentEncoding
+        $subscription = new Subscription("http://toto.com", "publicKey", "authToken", "aesgcm");
+        $this->assertEquals("http://toto.com", $subscription->getEndpoint());
+        $this->assertEquals("publicKey", $subscription->getPublicKey());
+        $this->assertEquals("authToken", $subscription->getAuthToken());
+        $this->assertEquals(ContentEncoding::aesgcm, $subscription->getContentEncoding());
+    }
     public function testCreatePartialWithNewStructure(): void
     {
         $subscription = Subscription::create([
@@ -112,6 +132,7 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
+        $this->assertEquals(ContentEncoding::aes128gcm, $subscription->getContentEncoding());
     }
 
     public function testCreatePartialWithNewStructureAndContentEncoding(): void
@@ -127,6 +148,6 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
-        $this->assertEquals("aes128gcm", $subscription->getContentEncoding());
+        $this->assertEquals(ContentEncoding::aes128gcm, $subscription->getContentEncoding());
     }
 }

--- a/tests/VAPIDTest.php
+++ b/tests/VAPIDTest.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  */
 
+use Minishlink\WebPush\ContentEncoding;
 use Minishlink\WebPush\Utils;
 use Minishlink\WebPush\VAPID;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -27,7 +28,7 @@ final class VAPIDTest extends PHPUnit\Framework\TestCase
                     'publicKey' => 'BA6jvk34k6YjElHQ6S0oZwmrsqHdCNajxcod6KJnI77Dagikfb--O_kYXcR2eflRz6l3PcI2r8fPCH3BElLQHDk',
                     'privateKey' => '-3CdhFOqjzixgAbUSa0Zv9zi-dwDVmWO7672aBxSFPQ',
                 ],
-                "aesgcm",
+                ContentEncoding::aesgcm,
                 1475452165,
                 'WebPush eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwOi8vcHVzaC5jb20iLCJleHAiOjE0NzU0NTIxNjUsInN1YiI6Imh0dHA6Ly90ZXN0LmNvbSJ9.4F3ZKjeru4P9XM20rHPNvGBcr9zxhz8_ViyNfe11_xcuy7A9y7KfEPt6yuNikyW7eT9zYYD5mQZubDGa-5H2cA',
                 'p256ecdsa=BA6jvk34k6YjElHQ6S0oZwmrsqHdCNajxcod6KJnI77Dagikfb--O_kYXcR2eflRz6l3PcI2r8fPCH3BElLQHDk',
@@ -38,7 +39,7 @@ final class VAPIDTest extends PHPUnit\Framework\TestCase
                     'publicKey' => 'BA6jvk34k6YjElHQ6S0oZwmrsqHdCNajxcod6KJnI77Dagikfb--O_kYXcR2eflRz6l3PcI2r8fPCH3BElLQHDk',
                     'privateKey' => '-3CdhFOqjzixgAbUSa0Zv9zi-dwDVmWO7672aBxSFPQ',
                 ],
-                "aes128gcm",
+                ContentEncoding::aes128gcm,
                 1475452165,
                 'vapid t=eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwOi8vcHVzaC5jb20iLCJleHAiOjE0NzU0NTIxNjUsInN1YiI6Imh0dHA6Ly90ZXN0LmNvbSJ9.4F3ZKjeru4P9XM20rHPNvGBcr9zxhz8_ViyNfe11_xcuy7A9y7KfEPt6yuNikyW7eT9zYYD5mQZubDGa-5H2cA, k=BA6jvk34k6YjElHQ6S0oZwmrsqHdCNajxcod6KJnI77Dagikfb--O_kYXcR2eflRz6l3PcI2r8fPCH3BElLQHDk',
                 null,
@@ -50,7 +51,7 @@ final class VAPIDTest extends PHPUnit\Framework\TestCase
      * @throws ErrorException
      */
     #[dataProvider('vapidProvider')]
-    public function testGetVapidHeaders(string $audience, array $vapid, string $contentEncoding, int $expiration, string $expectedAuthorization, ?string $expectedCryptoKey): void
+    public function testGetVapidHeaders(string $audience, array $vapid, ContentEncoding $contentEncoding, int $expiration, string $expectedAuthorization, ?string $expectedCryptoKey): void
     {
         $vapid = VAPID::validate($vapid);
         $headers = VAPID::getVapidHeaders(

--- a/tests/VAPIDTest.php
+++ b/tests/VAPIDTest.php
@@ -74,10 +74,6 @@ final class VAPIDTest extends PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @param string $auth
-     * @return array
-     */
     private function explodeAuthorization(string $auth): array
     {
         $auth = explode('.', $auth);


### PR DESCRIPTION
## Changes

Breaking:

- change default encoding to aes128g
- change subscription interface
- Remove legacy GCM
- Remove old Chrome subscription support

Feature:

- convert contentEncoding to typesafe enum

## Reference

fixes #381
fixes #345
reference #388