### PR TITLE
chore: use jwt-library instead of separate packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,13 @@
   "name": "minishlink/web-push",
   "type": "library",
   "description": "Web Push library for PHP",
-  "keywords": ["push", "notifications", "web", "WebPush", "Push API"],
+  "keywords": [
+    "push",
+    "notifications",
+    "web",
+    "WebPush",
+    "Push API"
+  ],
   "homepage": "https://github.com/web-push-libs/web-push-php",
   "license": "MIT",
   "authors": [
@@ -28,10 +34,7 @@
     "ext-mbstring": "*",
     "ext-openssl": "*",
     "guzzlehttp/guzzle": "^7.4.5",
-    "web-token/jwt-signature": "^3.2.9",
-    "web-token/jwt-key-mgmt": "^3.2.9",
-    "web-token/jwt-signature-algorithm-ecdsa": "^3.2.9",
-    "web-token/jwt-util-ecc": "^3.2.9",
+    "web-token/jwt-library": "^3.3.0",
     "spomky-labs/base64url": "^2.0.4"
   },
   "suggest": {


### PR DESCRIPTION
When installing this package, Composer will show the following warnings:
```
Package web-token/jwt-key-mgmt is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-signature is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-signature-algorithm-ecdsa is abandoned, you should avoid using it. Use web-token/jwt-library instead.
Package web-token/jwt-util-ecc is abandoned, you should avoid using it. Use web-token/jwt-library instead.
```
This PR replaces the abandoned packages by the `web-token/jwt-library` package.