### PR TITLE
Base64 backward compatibility and performance

### DIFF
--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -29,7 +29,7 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
     {
         // Base64 URL-safe, no padding
         $this->assertEquals('When I grow up, I want to be a watermelon', $this->base64Decode('V2hlbiBJIGdyb3cgdXAsIEkgd2FudCB0byBiZSBhIHdhdGVybWVsb24'));
-        $this->assertEquals('<<???>>', $this->base64Decode('PDwPz8-Pg'));
+        $this->assertEquals('<<???>>', $this->base64Decode('PDw_Pz8-Pg'));
 
         // Standard Base64
         $this->assertEquals('When I grow up, I want to be a watermelon', $this->base64Decode('V2hlbiBJIGdyb3cgdXAsIEkgd2FudCB0byBiZSBhIHdhdGVybWVsb24='));


### PR DESCRIPTION
Related to https://github.com/web-push-libs/web-push-php/pull/397

After replacing the spooky-labs/base64url library with another one, you lost backward compatibility since the new library can't decode standard base64 (non-URL safe). Also, the new library is much slower since it uses a pure PHP implementation of the base64 decoding algorithm.

This PR contains tests only, which are now falling on the master branch.

I would to borrow code here (from the old library) https://github.com/Spomky-Labs/base64url/blob/v2.x/src/Base64Url.php
and place it directly in the package, and refactor the code, of course.

The ideal solution would be to extract Base64 encoder as a dependency while adding the possibility of passing a custom encoder as a parameter.

Pseudo-code:

```
$myEncoder = new StandardBase64OnlyEncoder()
$wp = new WebPush();
$wp->setBase64Encoder($myEncoder);
```

However, it will require deep refractory; for example, the Encryption class must not be static anymore.
