### PR TITLE
Make use of Guzzle Pool to improve efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $notifications = [
         'payload' => '{"message":"Hello World!"}',
     ], [
           // current PushSubscription format (browsers might change this in the future)
-          'subscription' => Subscription::create([ 
+          'subscription' => Subscription::create([
               "endpoint" => "https://example.com/other/endpoint/of/another/vendor/abcdef...",
               "keys" => [
                   'p256dh' => '(stringOf88Chars)',
@@ -253,18 +253,18 @@ foreach ($webPush->flush() as $report) {
         echo "[v] Message sent successfully for subscription {$endpoint}.";
     } else {
         echo "[x] Message failed to sent for subscription {$endpoint}: {$report->getReason()}";
-        
+
         // also available (to get more info)
-        
+
         /** @var \Psr\Http\Message\RequestInterface $requestToPushService */
         $requestToPushService = $report->getRequest();
-        
+
         /** @var \Psr\Http\Message\ResponseInterface $responseOfPushService */
         $responseOfPushService = $report->getResponse();
-        
+
         /** @var string $failReason */
         $failReason = $report->getReason();
-        
+
         /** @var bool $isTheEndpointWrongOrExpired */
         $isTheEndpointWrongOrExpired = $report->isSubscriptionExpired();
     }
@@ -364,6 +364,7 @@ Here are some ideas:
 1. Make sure MultiCurl is available on your server
 2. Find the right balance for your needs between security and performance (see above)
 3. Find the right batch size (set it in `defaultOptions` or as parameter to `flush()`)
+4. Use `flushPooled()` instead of `flush()`. The former uses concurrent requests, accelerating the process and often doubling the speed of the requests.
 
 ### How to solve "SSL certificate problem: unable to get local issuer certificate"?
 

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -31,7 +31,7 @@ class WebPush
     protected ?array $notifications = null;
 
     /**
-     * @var array Default options: TTL, urgency, topic, batchSize
+     * @var array Default options: TTL, urgency, topic, batchSize, concurrency
      */
     protected array $defaultOptions;
 
@@ -54,7 +54,7 @@ class WebPush
      * WebPush constructor.
      *
      * @param array    $auth           Some servers need authentication
-     * @param array    $defaultOptions TTL, urgency, topic, batchSize
+     * @param array    $defaultOptions TTL, urgency, topic, batchSize, concurrency
      * @param int|null $timeout        Timeout of POST request
      *
      * @throws \ErrorException
@@ -205,7 +205,7 @@ class WebPush
             $pool = new Pool($this->client, $batch, [
                 'concurrency' => $concurrency,
                 'fulfilled' => function (ResponseInterface $response, int $index) use ($callback, $batch) {
-                    /** @var RequestInterface $request **/
+                    /** @var \Psr\Http\Message\RequestInterface $request **/
                     $request = $batch[$index];
                     $callback(new MessageSentReport($request, $response));
                 },

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -216,7 +216,7 @@ class WebPush
                         $response = null;
                     }
                     $callback(new MessageSentReport($reason->getRequest(), $response, false, $reason->getMessage()));
-                }
+                },
             ]);
 
             $promise = $pool->promise();


### PR DESCRIPTION
Fixes #367, fixes #195.

Since making use of the `Pool` refrains from returning anything to the user, a `callback` argument is added in the new `flushPooled` function, which will get called for each response received.

It was mentioned in #367 to transform the `prepare` method into a Generator, but that's not possible if we want to be able to return the Request alongside the Response.