### PR TITLE
fix tests: replace deprecated option with new one

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ parameters:
     level: 7
     paths:
         - src
-    checkMissingIterableValueType: false
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         - '#Unreachable statement \- code above always terminates\.#'
+        - identifier: missingType.iterableValue


### PR DESCRIPTION
Currently, tests from PHPStan were using a deprecated option.
This PR simply replaces that option with the identical one suggested by PHPStan.