### PR TITLE
chore: allow jwt-library v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "ext-mbstring": "*",
     "ext-openssl": "*",
     "guzzlehttp/guzzle": "^7.4.5",
-    "web-token/jwt-library": "^3.3.0",
+    "web-token/jwt-library": "^3.3.0|^4.0",
     "spomky-labs/base64url": "^2.0.4"
   },
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "ext-mbstring": "*",
     "ext-openssl": "*",
     "guzzlehttp/guzzle": "^7.4.5",
-    "web-token/jwt-library": "^3.3.0|^4.0",
+    "web-token/jwt-library": "^3.3.0|^4.0.0",
     "spomky-labs/base64url": "^2.0.4"
   },
   "suggest": {


### PR DESCRIPTION
It allows jwt-library v4 to be used, but v3 is still allowed to prevent conflicts with other packages and allow PHP 8.1 and 8.2. No code changes are necessary for this major upgrade.