### PR TITLE
Fix private VAPID key padding when importing from PEM

### DIFF
--- a/src/VAPID.php
+++ b/src/VAPID.php
@@ -54,7 +54,7 @@ class VAPID
                 throw new \ErrorException('Failed to convert VAPID public key from hexadecimal to binary');
             }
             $vapid['publicKey'] = base64_encode($binaryPublicKey);
-            $vapid['privateKey'] = base64_encode(str_pad(Base64Url::decode($jwk->get('d')), 2 * self::PRIVATE_KEY_LENGTH, '0', STR_PAD_LEFT));
+            $vapid['privateKey'] = base64_encode(str_pad(Base64Url::decode($jwk->get('d')), self::PRIVATE_KEY_LENGTH, '0', STR_PAD_LEFT));
         }
 
         if (!isset($vapid['publicKey'])) {


### PR DESCRIPTION
The current code pads the private key until it reaches a length of 2 * PRIVATE_KEY_LENGTH, which is 64, however, below, there is a condition that ensure that the length of said private key is PRIVATE_KEY_LENGTH, which will always fail when the private was set by importing a PEM due to it being left padded too much.

I have removed the unnecessary padding.

Here is a video of showing it working properly:
https://github.com/user-attachments/assets/3d5610e3-faed-408d-8472-6452664f00ad

