### PR TITLE
feat(ci): add php8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.2', '8.3' ]
+        php: [ '8.1', '8.2', '8.3', '8.4' ]
         ext_base: [ 'none, dom, tokenizer, xml, xmlwriter,' ]
         ext_lib: [ 'curl, mbstring, openssl,' ]
         ext_optional: [ '', 'bcmath', 'gmp' ]
@@ -68,6 +68,7 @@ jobs:
         run: composer test:typing
 
       - name: Run php-cs-fixer
+        if:  ${{ matrix.php != '8.4' }}
         run: |
           composer test:syntax
           composer test:syntax_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,6 @@ jobs:
         run: composer test:typing
 
       - name: Run php-cs-fixer
-        if:  ${{ matrix.php != '8.4' }}
         run: |
           composer test:syntax
           composer test:syntax_tests

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "ext-json": "*",
     "ext-mbstring": "*",
     "ext-openssl": "*",
-    "guzzlehttp/guzzle": "^7.4.5",
+    "guzzlehttp/guzzle": "^7.9.2",
     "web-token/jwt-library": "^3.3.0|^4.0.0",
     "spomky-labs/base64url": "^2.0.4"
   },


### PR DESCRIPTION
Skip `php-cs-fixer` because currently no php8.4 support.

Fixes #422

### Breaking Change

Problem: php8.4 support starts with 7.8.2 but latest 7.9.x drops eol peer dependency guzzlehttp/psr7@v1
To avoid a peer dependency confusion enforce the latest release.
