### PR TITLE
feat: convert contentEncoding to typesafe enum

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -6,9 +6,10 @@ $rules  = [
     '@PSR12'                              => true, // The default rule.
     '@autoPHPMigration'                   => true, // Uses min PHP version for regular migrations.
     'blank_line_after_opening_tag'        => false, // Do not waste space between <?php and declare.
+    'declare_strict_types'                => true,
     'global_namespace_import'             => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
-    'php_unit_construct'                  => true,
     'php_unit_attributes'                 => true,
+    'php_unit_construct'                  => true,
     'php_unit_method_casing'              => true,
     'php_unit_test_class_requires_covers' => true,
     // Do not enable by default. These rules require review!! (but they are useful)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ $notifications = [
                   'p256dh' => '(stringOf88Chars)',
                   'auth' => '(stringOf24Chars)'
               ],
+              // key 'contentEncoding' is optional and defaults to Subscription::defaultContentEncoding
           ]),
           'payload' => '{"message":"Hello World!"}',
     ], [

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
     "phpunit/phpunit": "^11.5.46|^12.5.2",
     "phpstan/phpstan": "^2.1.33",
     "friendsofphp/php-cs-fixer": "^v3.91.3",
-    "symfony/polyfill-iconv": "^1.33"
+    "symfony/polyfill-iconv": "^1.33",
+    "phpstan/phpstan-strict-rules": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,9 @@ parameters:
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         - identifier: missingType.iterableValue
+    strictRules:
+        booleansInConditions: false
+        disallowedEmpty: false
+
+includes:
+    - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/src/ContentEncoding.php
+++ b/src/ContentEncoding.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Minishlink\WebPush;
+
+enum ContentEncoding: string
+{
+    /** Not recommended. Outdated historic encoding. Was used by some browsers before rfc standard. */
+    case aesgcm = "aesgcm";
+    /** Defined in rfc8291. */
+    case aes128gcm = "aes128gcm";
+}

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -15,12 +15,12 @@ namespace Minishlink\WebPush;
 
 class Subscription implements SubscriptionInterface
 {
-    public const defaultContentEncoding = ContentEncoding::aesgcm; // Default for legacy input. The next mayor will use "aes128gcm" as defined to rfc8291.
+    public const defaultContentEncoding = ContentEncoding::aesgcm; // Default for legacy input. The next major will use "aes128gcm" as defined to rfc8291.
     protected ?ContentEncoding $contentEncoding = null;
 
     /**
      * This is a data class. No key validation is done.
-     * @param string|\Minishlink\WebPush\ContentEncoding|null $contentEncoding (Optional) defaults to "aesgcm". The next mayor will use "aes128gcm" as defined to rfc8291.
+     * @param string|\Minishlink\WebPush\ContentEncoding|null $contentEncoding (Optional) defaults to "aesgcm". The next major will use "aes128gcm" as defined to rfc8291.
      */
     public function __construct(
         private string  $endpoint,

--- a/src/VAPID.php
+++ b/src/VAPID.php
@@ -103,7 +103,7 @@ class VAPID
         string $publicKey,
         #[\SensitiveParameter]
         string $privateKey,
-        string $contentEncoding,
+        ContentEncoding $contentEncoding,
         ?int $expiration = null,
     ): array {
         $expirationLimit = time() + 43200; // equal margin of error between 0 and 24h
@@ -145,19 +145,20 @@ class VAPID
         $jwt = $jwsCompactSerializer->serialize($jws, 0);
         $encodedPublicKey = Base64Url::encode($publicKey);
 
-        if ($contentEncoding === "aesgcm") {
+        if ($contentEncoding === ContentEncoding::aesgcm) {
             return [
                 'Authorization' => 'WebPush '.$jwt,
                 'Crypto-Key' => 'p256ecdsa='.$encodedPublicKey,
             ];
         }
 
-        if ($contentEncoding === 'aes128gcm') {
+        if ($contentEncoding === ContentEncoding::aes128gcm) {
             return [
                 'Authorization' => 'vapid t='.$jwt.', k='.$encodedPublicKey,
             ];
         }
 
+        // @phpstan-ignore deadCode.unreachable
         throw new \ErrorException('This content encoding is not supported');
     }
 

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -10,6 +10,7 @@
 
 use Base64Url\Base64Url;
 use Jose\Component\Core\JWK;
+use Minishlink\WebPush\ContentEncoding;
 use Minishlink\WebPush\Encryption;
 use Minishlink\WebPush\Utils;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -37,7 +38,7 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
 
     public function testDeterministicEncrypt(): void
     {
-        $contentEncoding = 'aes128gcm';
+        $contentEncoding = ContentEncoding::aes128gcm;
         $plaintext = 'When I grow up, I want to be a watermelon';
 
         $payload = Encryption::padPayload($plaintext, 0, $contentEncoding);
@@ -83,7 +84,7 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
         $localPublicKey = $this->base64Decode('BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8');
         $salt = $this->base64Decode('DGv6ra1nlYgDCS1FRnbzlw');
 
-        $result = Encryption::getContentCodingHeader($salt, $localPublicKey, "aes128gcm");
+        $result = Encryption::getContentCodingHeader($salt, $localPublicKey, ContentEncoding::aes128gcm);
         $expected = $this->base64Decode('DGv6ra1nlYgDCS1FRnbzlwAAEABBBP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8');
 
         $this->assertEquals(Utils::safeStrlen($expected), Utils::safeStrlen($result));
@@ -96,7 +97,7 @@ final class EncryptionTest extends PHPUnit\Framework\TestCase
     #[dataProvider('payloadProvider')]
     public function testPadPayload(string $payload, int $maxLengthToPad, int $expectedResLength): void
     {
-        $res = Encryption::padPayload($payload, $maxLengthToPad, 'aesgcm');
+        $res = Encryption::padPayload($payload, $maxLengthToPad, ContentEncoding::aesgcm);
 
         $this->assertStringContainsString('test', $res);
         $this->assertEquals($expectedResLength, Utils::safeStrlen($res));

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use Minishlink\WebPush\ContentEncoding;
 use Minishlink\WebPush\Subscription;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -16,6 +17,7 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertNull($subscription->getPublicKey());
         $this->assertNull($subscription->getAuthToken());
         $this->assertNull($subscription->getContentEncoding());
+        $this->assertNull($subscription->getContentEncodingTyped());
     }
 
     public function testConstructMinimal(): void
@@ -25,6 +27,7 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertNull($subscription->getPublicKey());
         $this->assertNull($subscription->getAuthToken());
         $this->assertNull($subscription->getContentEncoding());
+        $this->assertNull($subscription->getContentEncodingTyped());
     }
 
     public function testCreatePartial(): void
@@ -39,6 +42,7 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
         $this->assertEquals("aesgcm", $subscription->getContentEncoding());
+        $this->assertSame(ContentEncoding::aesgcm, $subscription->getContentEncodingTyped());
     }
 
     public function testConstructPartial(): void
@@ -47,11 +51,26 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
-        $this->assertEquals("aesgcm", $subscription->getContentEncoding());
+        $this->assertSame("aesgcm", $subscription->getContentEncoding());
+        $this->assertSame(ContentEncoding::aesgcm, $subscription->getContentEncodingTyped());
     }
 
     public function testCreateFull(): void
     {
+        $subscriptionArray = [
+            "endpoint" => "http://toto.com",
+            "publicKey" => "publicKey",
+            "authToken" => "authToken",
+            "contentEncoding" => ContentEncoding::aes128gcm,
+        ];
+        $subscription = Subscription::create($subscriptionArray);
+        $this->assertEquals("http://toto.com", $subscription->getEndpoint());
+        $this->assertEquals("publicKey", $subscription->getPublicKey());
+        $this->assertEquals("authToken", $subscription->getAuthToken());
+        $this->assertSame("aes128gcm", $subscription->getContentEncoding());
+        $this->assertSame(ContentEncoding::aes128gcm, $subscription->getContentEncodingTyped());
+
+        // Test with type string contentEncoding
         $subscriptionArray = [
             "endpoint" => "http://toto.com",
             "publicKey" => "publicKey",
@@ -62,18 +81,27 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
-        $this->assertEquals("aes128gcm", $subscription->getContentEncoding());
+        $this->assertSame("aes128gcm", $subscription->getContentEncoding());
+        $this->assertSame(ContentEncoding::aes128gcm, $subscription->getContentEncodingTyped());
     }
 
     public function testConstructFull(): void
     {
-        $subscription = new Subscription("http://toto.com", "publicKey", "authToken", "aes128gcm");
+        $subscription = new Subscription("http://toto.com", "publicKey", "authToken", ContentEncoding::aes128gcm);
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
-        $this->assertEquals("aes128gcm", $subscription->getContentEncoding());
-    }
+        $this->assertSame("aes128gcm", $subscription->getContentEncoding());
+        $this->assertSame(ContentEncoding::aes128gcm, $subscription->getContentEncodingTyped());
 
+        // Test with type string contentEncoding
+        $subscription = new Subscription("http://toto.com", "publicKey", "authToken", "aesgcm");
+        $this->assertEquals("http://toto.com", $subscription->getEndpoint());
+        $this->assertEquals("publicKey", $subscription->getPublicKey());
+        $this->assertEquals("authToken", $subscription->getAuthToken());
+        $this->assertSame("aesgcm", $subscription->getContentEncoding());
+        $this->assertSame(ContentEncoding::aesgcm, $subscription->getContentEncodingTyped());
+    }
     public function testCreatePartialWithNewStructure(): void
     {
         $subscription = Subscription::create([
@@ -86,6 +114,8 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
+        $this->assertSame("aesgcm", $subscription->getContentEncoding());
+        $this->assertSame(ContentEncoding::aesgcm, $subscription->getContentEncodingTyped());
     }
 
     public function testCreatePartialWithNewStructureAndContentEncoding(): void
@@ -101,6 +131,7 @@ class SubscriptionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("http://toto.com", $subscription->getEndpoint());
         $this->assertEquals("publicKey", $subscription->getPublicKey());
         $this->assertEquals("authToken", $subscription->getAuthToken());
-        $this->assertEquals("aes128gcm", $subscription->getContentEncoding());
+        $this->assertSame("aes128gcm", $subscription->getContentEncoding());
+        $this->assertSame(ContentEncoding::aes128gcm, $subscription->getContentEncodingTyped());
     }
 }

--- a/tests/VAPIDTest.php
+++ b/tests/VAPIDTest.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  */
 
+use Minishlink\WebPush\ContentEncoding;
 use Minishlink\WebPush\Utils;
 use Minishlink\WebPush\VAPID;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -26,7 +27,7 @@ final class VAPIDTest extends PHPUnit\Framework\TestCase
                     'publicKey' => 'BA6jvk34k6YjElHQ6S0oZwmrsqHdCNajxcod6KJnI77Dagikfb--O_kYXcR2eflRz6l3PcI2r8fPCH3BElLQHDk',
                     'privateKey' => '-3CdhFOqjzixgAbUSa0Zv9zi-dwDVmWO7672aBxSFPQ',
                 ],
-                "aesgcm",
+                ContentEncoding::aesgcm,
                 1475452165,
                 'WebPush eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwOi8vcHVzaC5jb20iLCJleHAiOjE0NzU0NTIxNjUsInN1YiI6Imh0dHA6Ly90ZXN0LmNvbSJ9.4F3ZKjeru4P9XM20rHPNvGBcr9zxhz8_ViyNfe11_xcuy7A9y7KfEPt6yuNikyW7eT9zYYD5mQZubDGa-5H2cA',
                 'p256ecdsa=BA6jvk34k6YjElHQ6S0oZwmrsqHdCNajxcod6KJnI77Dagikfb--O_kYXcR2eflRz6l3PcI2r8fPCH3BElLQHDk',
@@ -37,7 +38,7 @@ final class VAPIDTest extends PHPUnit\Framework\TestCase
                     'publicKey' => 'BA6jvk34k6YjElHQ6S0oZwmrsqHdCNajxcod6KJnI77Dagikfb--O_kYXcR2eflRz6l3PcI2r8fPCH3BElLQHDk',
                     'privateKey' => '-3CdhFOqjzixgAbUSa0Zv9zi-dwDVmWO7672aBxSFPQ',
                 ],
-                "aes128gcm",
+                ContentEncoding::aes128gcm,
                 1475452165,
                 'vapid t=eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwOi8vcHVzaC5jb20iLCJleHAiOjE0NzU0NTIxNjUsInN1YiI6Imh0dHA6Ly90ZXN0LmNvbSJ9.4F3ZKjeru4P9XM20rHPNvGBcr9zxhz8_ViyNfe11_xcuy7A9y7KfEPt6yuNikyW7eT9zYYD5mQZubDGa-5H2cA, k=BA6jvk34k6YjElHQ6S0oZwmrsqHdCNajxcod6KJnI77Dagikfb--O_kYXcR2eflRz6l3PcI2r8fPCH3BElLQHDk',
                 null,
@@ -49,7 +50,7 @@ final class VAPIDTest extends PHPUnit\Framework\TestCase
      * @throws ErrorException
      */
     #[dataProvider('vapidProvider')]
-    public function testGetVapidHeaders(string $audience, array $vapid, string $contentEncoding, int $expiration, string $expectedAuthorization, ?string $expectedCryptoKey): void
+    public function testGetVapidHeaders(string $audience, array $vapid, ContentEncoding $contentEncoding, int $expiration, string $expectedAuthorization, ?string $expectedCryptoKey): void
     {
         $vapid = VAPID::validate($vapid);
         $headers = VAPID::getVapidHeaders(


### PR DESCRIPTION
Modified part from #394 without breaking changes so it can be merged and released as patch release.

### Changes

Feature:

- convert contentEncoding to typesafe enum

### Reference

Partially address #381
