### PR TITLE
feat: add contentType option

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ $defaultOptions = [
     'urgency' => 'normal', // protocol defaults to "normal". (very-low, low, normal, or high)
     'topic' => 'newEvent', // not defined by default. Max. 32 characters from the URL or filename-safe Base64 characters sets
     'batchSize' => 200, // defaults to 1000
+    'contentType' => 'application/json', // defaults to "application/octet-stream"
 ];
 
 // for every notification
@@ -234,6 +235,11 @@ If you send tens of thousands notifications at a time, you may get memory overfl
 In order to fix this, WebPush sends notifications in batches. The default size is 1000. Depending on your server configuration (memory), you may want
 to decrease this number. Do this while instantiating WebPush or calling `setDefaultOptions`. Or, if you want to customize this for a specific flush, give
 it as a parameter : `$webPush->flush($batchSize)`.
+
+#### contentType
+
+Sets the "Content-Type" header for HTTP requests with a non-empty payload sent to the push service. 
+Especially newer [Declarative push messages](https://www.w3.org/TR/push-api/#declarative-push-message) require a specific JSON payload, so this should be set to "application/json" in such cases.
 
 ### Server errors
 

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -43,6 +43,7 @@ class Notification
         $options['TTL'] = array_key_exists('TTL', $options) ? $options['TTL'] : $defaultOptions['TTL'];
         $options['urgency'] = array_key_exists('urgency', $options) ? $options['urgency'] : $defaultOptions['urgency'];
         $options['topic'] = array_key_exists('topic', $options) ? $options['topic'] : $defaultOptions['topic'];
+        $options['contentType'] = array_key_exists('contentType', $options) ? $options['contentType'] : $defaultOptions['contentType'];
 
         return $options;
     }

--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -263,7 +263,7 @@ class WebPush
                 $localPublicKey = $encrypted['localPublicKey'];
 
                 $headers = [
-                    'Content-Type' => 'application/octet-stream',
+                    'Content-Type' => $options['contentType'],
                     'Content-Encoding' => $contentEncoding,
                 ];
 
@@ -384,6 +384,7 @@ class WebPush
         $this->defaultOptions['topic'] = $defaultOptions['topic'] ?? null;
         $this->defaultOptions['batchSize'] = $defaultOptions['batchSize'] ?? 1000;
         $this->defaultOptions['requestConcurrency'] = $defaultOptions['requestConcurrency'] ?? 100;
+        $this->defaultOptions['contentType'] = $defaultOptions['contentType'] ?? 'application/octet-stream';
 
 
         return $this;


### PR DESCRIPTION
Hey there 👋 

In order to support [Declarative Web Push messages](https://www.w3.org/TR/push-api/#declarative-push-message), which aim to reduce the complexity of using push on the web in general and address some challenges like privacy & battery life on mobile, a well-defined JSON body needs to be sent as payload to the push service. See also https://webkit.org/blog/16535/meet-declarative-web-push.

Since this payload is always a JSON object, the content type header of the HTTP request should be set accordingly. Which is why this pull request introduces the ability to configure on a global or per-notification basis the content type that should be set for the HTTP request to the push service.

While in practice most payloads probably are a JSON object already, I opted to make the content type header option an explicit opt-in and leave the default at `application/octet-stream` in order to not introduce any breaking changes.

Video 1: Sample app as-is
https://github.com/user-attachments/assets/6fbde6ed-3edb-4b30-a7a7-fe93f1f09e24

Video 2: Sample app modified with contentType "application/json" option
https://github.com/user-attachments/assets/ed71be90-79ad-46c4-b2dd-446bea16cc05


