### PR TITLE
fix: EC key generation for OpenSSL 3.6+

### DIFF
--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -251,8 +251,10 @@ class Encryption
     private static function createLocalKeyObject(): array
     {
         $keyResource = openssl_pkey_new([
-            'curve_name'       => 'prime256v1',
-            'private_key_type' => OPENSSL_KEYTYPE_EC,
+            'ec' => [
+                'curve_name'       => 'prime256v1',
+                'private_key_type' => OPENSSL_KEYTYPE_EC,
+            ],
         ]);
         if (!$keyResource) {
             throw new \RuntimeException('Unable to create the local key.');


### PR DESCRIPTION
OpenSSL 3.6 requires EC-specific parameters to be nested under an \`ec\` sub-array when calling \`openssl_pkey_new()\`. The flat top-level form fails with:

    openssl_pkey_new(): Private key length must be at least 384 bits, configured to 0

Nest both keys inside \`['ec' => [...]]\`.

## Reference

Closes #445