### PR TITLE
feat: return static on Subscription::create()

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -10,6 +10,10 @@
 
 namespace Minishlink\WebPush;
 
+/**
+ * @phpstan-consistent-constructor
+ * @psalm-consistent-constructor
+ */
 class Subscription implements SubscriptionInterface
 {
     public const defaultContentEncoding = ContentEncoding::aesgcm; // Default for legacy input. The next major will use "aes128gcm" as defined to rfc8291.
@@ -47,10 +51,10 @@ class Subscription implements SubscriptionInterface
      * @param array $associativeArray (with keys endpoint, publicKey, authToken, contentEncoding)
      * @throws \ErrorException
      */
-    public static function create(array $associativeArray): self
+    public static function create(array $associativeArray): static
     {
         if (array_key_exists('keys', $associativeArray) && is_array($associativeArray['keys'])) {
-            return new self(
+            return new static(
                 $associativeArray['endpoint'],
                 $associativeArray['keys']['p256dh'] ?? null,
                 $associativeArray['keys']['auth'] ?? null,
@@ -59,7 +63,7 @@ class Subscription implements SubscriptionInterface
         }
 
         if (array_key_exists('publicKey', $associativeArray) || array_key_exists('authToken', $associativeArray) || array_key_exists('contentEncoding', $associativeArray)) {
-            return new self(
+            return new static(
                 $associativeArray['endpoint'],
                 $associativeArray['publicKey'] ?? null,
                 $associativeArray['authToken'] ?? null,
@@ -67,7 +71,7 @@ class Subscription implements SubscriptionInterface
             );
         }
 
-        return new self(
+        return new static(
             $associativeArray['endpoint']
         );
     }


### PR DESCRIPTION
Currently, `Subscription::create()` returns `self`, despite the class not being `final`.

This PR changes the return type to `static`, so child classes can be created using the method.

I ran into this when I extended the class to add some custom serialization/deserialization to fit within our application.

I added the `consistent-constructor` annotations to prevent problems with child classes overriding the constructor. Alternatively, the constructor could be made `final`, but I feel this is preferable, leaving more room to the user while notifying static-analysis tools of the risks.