### PR TITLE
Cast TTL option to string in headers to avoid Guzzle deprecation warnings

### DIFF
--- a/src/WebPush.php
+++ b/src/WebPush.php
@@ -286,7 +286,7 @@ class WebPush
                 $content = '';
             }
 
-            $headers['TTL'] = $options['TTL'];
+            $headers['TTL'] = (string) $options['TTL'];
 
             if (isset($options['urgency'])) {
                 $headers['Urgency'] = $options['urgency'];


### PR DESCRIPTION
Fixes #455 